### PR TITLE
Raspberry Pi Bullseye upstream fix

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ else
 fi
 
 printf "\n===== OS update =====\n"
-sudo apt update -y --fix-missing
+sudo apt-get update --allow-releaseinfo-change --fix-missing
 
 printf "\n===== Audio card setup =====\n"
 setup/audio/audioinjector-setup.sh


### PR DESCRIPTION
Bullseye upstream is causing apt-get update to fail even with --fix-missing, so --allow-releaseinfo-change needs to be added to get around this.