### PR TITLE
Setup fix and interrupt based encoder

### DIFF
--- a/setup/audio/audioinjector-setup.sh
+++ b/setup/audio/audioinjector-setup.sh
@@ -30,6 +30,12 @@ sudo sed -i 's/sudo rpi-update/#sudo rpi-update/' /usr/bin/audioInjector-setup.s
 
 # Change jack config to use the audioinjector card 
 sudo sed -i -e 's/hw:pisound/hw:audioinjectorpi/' /etc/jackdrc
+if ! grep -q audioinjectorpi /etc/jackdrc ; then
+    sudo sed -i -e 's/hw:b1/hw:audioinjectorpi/' /etc/jackdrc
+fi
+if ! grep -q audioinjectorpi /etc/jackdrc ; then
+    sudo sed -i -e 's/hw:Headphones/hw:audioinjectorpi/' /etc/jackdrc
+fi
 
 # Change amixer settings
 sudo cp setup/audio/asound.state.RCA.thru.test /usr/share/doc/audioInjector/asound.state.RCA.thru.test


### PR DESCRIPTION
This has a small "fix" for the setup script so that it will properly configure the audio card if the user has gone
through the patchbox initial setup wizard (which tries to force you to select one of the two built-in audio
devices, hdmi and headphones).

There's also a change to the encoder code to use interrupt driven GPIOs. This makes my encoder works, it's otherwise unusable (unless you turn it very very slowly as to increase the duration of the "pulses"). I am pretty confident a lot of the problems people have been experiencing are related to encoders generating too fast pulses with a too low sampling rate.

I've run a number of tests with a pedal board hovering around 80% idle, with and without interrupts, and I seem to
get about the same amount of small overruns when actively manipulating the encoder. (a dozen after 2 or 3 seconds of manipulating, more if I use the "settings" menu). I get no overruns with a pedal board idling at 73%. In any case, I don't seem to see a negative impact to using interrupts.

The code is a bit refactored from what I posted to the forums: a use_interrupt argument to the constructor (default to True) was added so it's easy to revert to the old behaviour if a problem happens (at the very least as a way to test if this is causing said problem).