### PR TITLE
Footswitch halo behaviour changes

### DIFF
--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -834,7 +834,7 @@ class Mod(Handler):
 
             if footswitch is not None:
                 # Update LED
-                footswitch.set_led(relay.enabled)
+                footswitch.set_value(int(not relay.enabled))
 
     #
     # Parameter Edit
@@ -939,5 +939,4 @@ class Mod(Handler):
     def update_lcd_fs(self, bypass_change=False):
         if bypass_change:
             self.lcd.update_bypass(self.hardware.relay.enabled)
-        else:
-            self.lcd.draw_bound_plugins(self.current.pedalboard.plugins, self.hardware.footswitches)
+        self.lcd.draw_bound_plugins(self.current.pedalboard.plugins, self.hardware.footswitches)

--- a/pistomp/footswitch.py
+++ b/pistomp/footswitch.py
@@ -109,10 +109,12 @@ class Footswitch(controller.Controller):
             logging.debug("Sending CC event: %d %s" % (self.midi_CC, gpio))
             self.midiout.send_message(cc)
 
-        # Update LCD
+        # Update plugin parameter if any
         if self.parameter is not None:
             self.parameter.value = not self.enabled  # TODO assumes mapped parameter is :bypass
-            self.refresh_callback()
+
+        # Update LCD
+        self.refresh_callback()
 
     def set_display_label(self, label):
         self.display_label = label

--- a/pistomp/lcdbase.py
+++ b/pistomp/lcdbase.py
@@ -188,6 +188,8 @@ class Lcdbase(abstract_lcd.Lcd):
                 continue
             f = fss[fs_id]
             color = self.valid_color(f.lcd_color)
+            if self.color_plugin_bypassed is not None and not f.enabled:
+                color = self.color_plugin_bypassed
             label = "" if f.display_label is None else f.display_label
             x = self.footswitch_pitch[len(fss)] * fs_id
             self.draw_plugin(zone, x, 0, label, self.footswitch_width, False, None, True, color)

--- a/pistomp/lcdcolor.py
+++ b/pistomp/lcdcolor.py
@@ -254,7 +254,7 @@ class Lcdcolor(lcdbase.Lcdbase):
         if is_footswitch:
             if plugin:
                 plugin.lcd_xyz = (xy1, xy2, zone)
-            c = self.color_plugin_bypassed if plugin is None or plugin.is_bypassed() else color
+            c = self.color_plugin_bypassed if plugin is not None and plugin.is_bypassed() else color
             self.draw_footswitch(xy1, xy2, zone, text, c)
         elif plugin:
             plugin.lcd_xyz = (xy1, xy2, zone)


### PR DESCRIPTION
This makes footswitches that aren't bound to a MIDI message or relay
not toggle. It also synchronizes the LCD halo with the LED one if any,
so that the LCD halo of the relay switch toggles along with the relay
as happens on "normal" pedals.
