### PR TITLE
Switches GPIO fixes

### DIFF
--- a/pistomp/encoder.py
+++ b/pistomp/encoder.py
@@ -75,6 +75,9 @@ class Encoder:
         # 16 possible grey codes.  1=Valid, 0=Invalid (bounce)
         self.rot_enc_table = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
 
+    def __del__(self):
+        GPIO.remove_event_detect(self._gpio_callback)
+
     def get_data(self):
         return GPIO.input(self.d_pin)
 

--- a/pistomp/encoderswitch.py
+++ b/pistomp/encoderswitch.py
@@ -14,8 +14,8 @@
 # along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
 
 from enum import Enum
-import RPi.GPIO as GPIO
 
+import pistomp.gpioswitch as gpioswitch
 import time
 
 class Value(Enum):
@@ -27,35 +27,16 @@ class Value(Enum):
     DOUBLECLICKED = 5
 
 
-class EncoderSwitch:
+class EncoderSwitch(gpioswitch.GpioSwitch):
 
     def __init__(self, gpio, callback):
-        #super(AnalogSwitch, self).__init__(spi, adc_channel, tolerance)
+        super(EncoderSwitch, self).__init__(gpio, None, None)
         self.last_read = None          # this keeps track of the last value
         self.trigger_count = 0
         self.callback = callback
         self.longpress_state = False
         self.gpio = gpio
 
-        self.poll_interval = 0.26
-        self.poll_intervals = 2
-
-        GPIO.setup(gpio, GPIO.IN, pull_up_down=GPIO.PUD_UP)
-        GPIO.add_event_detect(gpio, GPIO.FALLING, callback=self.pressed, bouncetime=250)
-
-
     # Override of base class method
-    def pressed(self, foo):
-        value = Value.RELEASED
-        short = False
-        for i in range(self.poll_intervals):
-            time.sleep(self.poll_interval)
-            if GPIO.input(self.gpio):
-                # Pin went high before timed polling was complete (short press)
-                short = True
-                break
-        if short is False:
-            # Pin kept low (long press)
-            value = Value.LONGPRESSED
-
-        self.callback(value)
+    def pressed(self, short):
+        self.callback(Value.RELEASED if short else Value.LONGPRESSED)

--- a/pistomp/footswitch.py
+++ b/pistomp/footswitch.py
@@ -18,7 +18,6 @@ import RPi.GPIO as GPIO
 from rtmidi.midiconstants import CONTROL_CHANGE
 
 import pistomp.gpioswitch as gpioswitch
-import queue
 
 class Footswitch(gpioswitch.GpioSwitch):
 

--- a/pistomp/gpioswitch.py
+++ b/pistomp/gpioswitch.py
@@ -1,0 +1,82 @@
+# This file is part of pi-stomp.
+#
+# pi-stomp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pi-stomp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import RPi.GPIO as GPIO
+from rtmidi.midiconstants import CONTROL_CHANGE
+
+import pistomp.controller as controller
+import time
+import queue
+
+class GpioSwitch(controller.Controller):
+
+    def __init__(self, fs_pin, midi_channel, midi_CC):
+        super(GpioSwitch, self).__init__(midi_channel, midi_CC)
+        self.fs_pin = fs_pin
+        self.cur_tstamp = None
+        self.events = queue.Queue()
+
+        # Long press threshold in seconds
+        self.long_press_threshold = 0.5
+
+        GPIO.setup(fs_pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+        GPIO.add_event_detect(fs_pin, GPIO.FALLING, callback=self._gpio_down, bouncetime=250)
+
+    def __del__(self):
+        GPIO.remove_event_detect(self.fs_pin)
+
+    def _gpio_down(self, gpio):
+        # This is run from a separate thread, timestamp pressed and queue an event
+        #
+        # I considered using a dual edge callback and handle the timestamp here
+        # to queue long/short press events, but in practice, I noticed dual edge
+        # is rather unreliable with such a long debounce, we often don't get the
+        # rising edge callback at all. So let's just timestamp and we'll handle
+        # everything from the poller thread
+        #
+        self.events.put(time.monotonic())
+
+    def poll(self):
+        # Grab press event if any
+        if not self.events.empty():
+            new_tstamp = self.events.get_nowait()
+        else:
+            new_tstamp = None
+
+        # If we were a already pressed and waiting for a release, drop it, it's easier
+        # that way and we should be polling fast enough for this not to matter.
+        # Otherwise record it
+        if self.cur_tstamp is None:
+            self.cur_tstamp = new_tstamp
+
+        # Are we waiting for release ?
+        if self.cur_tstamp is None:
+            return
+
+        time_pressed = time.monotonic() - self.cur_tstamp
+
+        # If it's a long press, process as soon as we reach the threshold, otherwise
+        # check the GPIO input
+        if time_pressed > self.long_press_threshold:
+            short = False
+        elif GPIO.input(self.fs_pin):
+            short = True
+        else:
+            return
+        self.cur_tstamp = None
+
+        logging.debug("Switch %d %s press" % (self.fs_pin, "short" if short else "long"))
+        self.pressed(short)

--- a/pistomp/hardware.py
+++ b/pistomp/hardware.py
@@ -48,6 +48,7 @@ class Hardware:
         self.encoders = []
         self.controllers = {}
         self.footswitches = []
+        self.encoder_switches = []
         self.debounce_map = None
 
     def init_spi(self):
@@ -67,6 +68,8 @@ class Hardware:
             c.refresh()
         for e in self.encoders:
             e.read_rotary()
+        for s in self.encoder_switches:
+            s.poll()
         for s in self.footswitches:
             s.poll()
 

--- a/pistomp/hardware.py
+++ b/pistomp/hardware.py
@@ -67,6 +67,8 @@ class Hardware:
             c.refresh()
         for e in self.encoders:
             e.read_rotary()
+        for s in self.footswitches:
+            s.poll()
 
     def reinit(self, cfg):
         # reinit hardware as specified by the new cfg context (after pedalboard change, etc.)

--- a/pistomp/pistompcore.py
+++ b/pistomp/pistompcore.py
@@ -86,7 +86,8 @@ class Pistompcore(hardware.Hardware):
     def init_encoders(self):
         top_enc = Encoder.Encoder(TOP_ENC_PIN_D, TOP_ENC_PIN_CLK, callback=self.mod.universal_encoder_select)
         self.encoders.append(top_enc)
-        EncoderSwitch.EncoderSwitch(1, callback=self.mod.universal_encoder_sw)
+        enc_sw = EncoderSwitch.EncoderSwitch(1, callback=self.mod.universal_encoder_sw)
+        self.encoder_switches.append(enc_sw)
 
     def init_relays(self):
         self.relay = Relay.Relay(RELAY_SET_PIN, RELAY_RESET_PIN)


### PR DESCRIPTION
[Note: This branch is on top of the halo behaviour change one, I can rebase if you merge the previous one first]

This series reworks the footswitch and encoder switch code to avoid calling back into the core of pistomp from
the GPIO callbacks. Those callbacks are called by separate threads created by the GPIO library and we lack
the necessary synchronization to make it safe.

While at it, move the logic to a common subclass to both type of switch