### PR TITLE
setup: Don't enable ttymidi by default

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,18 +19,40 @@
 #
 # Usage and options
 #
-usage() { echo "Usage: $(basename $0) [-v <hardware_version>]" 1>&2; exit 1; }
+usage()
+{
+    echo "Usage: $(basename $0) [-v <hardware_version>] [-m]"
+    echo ""
+    echo "Options:"
+    echo " -v <version>          Specify hardware version"
+    echo "                         1.0 : original pi-Stomp hardware (PCB v1)"
+    echo "                         2.0 : most hardware (default)"
+    echo " -m                    Enable MIDI via UART"
+    echo " -h                    Display this message"    
+}
+
+has_ttymidi=false
 
 while getopts ':v:' o; do
     case "${o}" in
         v)
             hardware_version=${OPTARG}
             ;;
+	m)
+	    has_ttymidi=true
+	    ;;
+	h)
+	    usage
+	    exit 0
+	    ;;
         *)
-            usage
+            usage 1>&2
+	    exit 1
             ;;
     esac
 done
+
+export has_ttymidi
 
 #
 # Hardware specific

--- a/setup/services/create_services.sh
+++ b/setup/services/create_services.sh
@@ -17,4 +17,8 @@
 
 sudo cp setup/services/*.service /usr/lib/systemd/system/
 sudo ln -sf /usr/lib/systemd/system/mod-ala-pi-stomp.service /etc/systemd/system/multi-user.target.wants
-sudo ln -sf /usr/lib/systemd/system/ttymidi.service /etc/systemd/system/multi-user.target.wants
+
+if [ x"$has_ttymidi" == x"true" ]; then
+    echo "Enabling ttymidi service"
+    sudo ln -sf /usr/lib/systemd/system/ttymidi.service /etc/systemd/system/multi-user.target.wants
+fi


### PR DESCRIPTION
add a -m option to setup to do it

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>