### PR TITLE
[RFC] wifi: Rework/improve wifi status

### DIFF
--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -86,7 +86,7 @@ class Mod(Handler):
     __single = None
 
     def __init__(self, audiocard, homedir):
-        self.wifi_monitor = None
+        self.wifi_manager = None
 
         logging.info("Init mod")
         if Mod.__single:
@@ -127,12 +127,12 @@ class Mod(Handler):
         self.menu_items = None
         self.current_menu = MenuType.MENU_NONE
 
-        self.wifi_monitor = Wifi.WifiMonitor()
+        self.wifi_manager = Wifi.WifiManager()
 
     def __del__(self):
         logging.info("Handler cleanup")
-        if self.wifi_monitor:
-            del self.wifi_monitor
+        if self.wifi_manager:
+            del self.wifi_manager
 
     # Container for dynamic data which is unique to the "current" pedalboard
     # The self.current pointed above will point to this object which gets
@@ -379,7 +379,7 @@ class Mod(Handler):
     def poll_controls(self):
         if self.universal_encoder_mode is not UniversalEncoderMode.LOADING:
             self.hardware.poll_controls()
-        wifi_update = self.wifi_monitor.poll()
+        wifi_update = self.wifi_manager.poll()
         if wifi_update is not None:
             self.wifi_status = wifi_update
             self.lcd.update_wifi(self.wifi_status)
@@ -777,17 +777,12 @@ class Mod(Handler):
         self.lcd.menu_highlight(self.selected_menu_index)
 
     def system_disable_hotspot(self):
-        self.system_toggle_hotspot("Disabling, please wait...", "/usr/bin/patchbox wifi hotspot down")
+        self.lcd.draw_info_message("Disabling, please wait...")
+        self.wifi_manager.disable_hotspot()
 
     def system_enable_hotspot(self):
-        self.system_toggle_hotspot("Enabling, please wait...", "/usr/bin/patchbox wifi hotspot up")
-
-    def system_toggle_hotspot(self, msg, cmd):
-        self.lcd.draw_info_message(msg)
-        subprocess.check_output(cmd, shell=True)
-#        time.sleep(2)  # Give networking time to settle before refreshing info
-#        self.system_info_load()
-#        self.system_info_show()
+        self.lcd.draw_info_message("Enabling, please wait...")
+        self.wifi_manager.enable_hotspot()
 
     def system_menu_save_current_pb(self):
         logging.debug("save current")

--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -1,0 +1,105 @@
+# This file is part of pi-stomp.
+#
+# pi-stomp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pi-stomp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Parts of this file borrowed from patchbox-cli
+#
+# Copyright (C) 2017  Vilniaus Blokas UAB, https://blokas.io/pisound
+
+import os
+import threading
+import subprocess
+import logging
+
+class WifiMonitor():
+
+    # For now hard wire wifi interface to avoid spending time scrubbing sysfs
+    #
+    # our hotspot scripts are also hard wired to this name. Long run we could make
+    # it a config option or similar... or better plumb the whole thing with a
+    # proper network management, but we aren't there. Alternatively, we could
+    # monitor for hotplug events via dbus...
+    #
+    def __init__(self, ifname = 'wlan0'):
+        # Grab default wifi interface
+        self.iface_name = 'wlan0'
+        self.lock = threading.Lock()
+        self.last_status = {}
+        self.changed = False
+        self.stop = threading.Event()
+        self.thread = threading.Thread(target=self._polling_thread, daemon=True).start()
+
+    def __del__(self):
+        logging.info("Wifi monitor cleanup")
+        self.stop.set()
+        self.thread.join()
+
+    def _is_wifi_supported(self):
+        return os.path.exists('/sys/class/net/' + self.iface_name + '/wireless')
+    
+    def _is_wifi_connected(self):
+        try:
+            output = subprocess.check_output(['cat', '/sys/class/net/{}/operstate'.format(self.iface_name)])
+            return output.strip().decode('utf-8') == 'up'
+        except Exception as e:
+            return False
+
+    def _is_hotspot_active(self):
+        try:
+            subprocess.check_output(['systemctl', 'is-active', 'wifi-hotspot', '--quiet']).strip().decode('utf-8')
+        except:
+            return False
+        return True
+
+    def _get_wpa_status(self, status):
+        try:
+            text_out = subprocess.check_output(['wpa_cli', '-i', self.iface_name, 'status']).strip().decode('utf-8')
+            for i in text_out.split('\n'):
+                if len(i) is 0:
+                    continue
+                (key, value) = i.split('=')
+                if key and value:
+                    status[key] = value
+        except Exception as e:
+            print("WPA CLI fail:" + str(e))
+
+    def _polling_thread(self):
+        while not self.stop.wait(1.0):
+            new_status = {}
+            new_status['wifi_supported'] = supported = self._is_wifi_supported()
+            new_status['wifi_connected'] = connected = self._is_wifi_connected()
+            new_status['hotspot_active'] = hp_active = self._is_hotspot_active()
+            if supported and (connected or hp_active):
+                self._get_wpa_status(new_status)
+            if new_status != self.last_status:
+                logging.debug("Wifi status changed:" + str(new_status))
+                self.lock.acquire()
+                self.last_status = new_status
+                self.changed = True
+                self.lock.release()
+
+    # External API
+    def poll(self):
+        if self.changed:
+            logging.debug("wifi poll changed detect !")
+            # We don't need to do a deep copy because that dictionnary content
+            # is never modified by the Timer thread (the whole dictionnary is
+            # replaced)
+            #
+            # Note: Use context manager to use a non-blocking lock safely vs. ctrl-C
+            with self.lock:
+                update = self.last_status
+                self.changed = False
+            return update
+        return None

--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -22,7 +22,7 @@ import threading
 import subprocess
 import logging
 
-class WifiMonitor():
+class WifiManager():
 
     # For now hard wire wifi interface to avoid spending time scrubbing sysfs
     #
@@ -103,3 +103,17 @@ class WifiMonitor():
                 self.changed = False
             return update
         return None
+
+    def enable_hotspot(self):
+        try:
+            subprocess.check_output(['sudo', 'systemctl', 'enable', 'wifi-hotspot']).strip().decode('utf-8')
+            subprocess.check_output(['sudo', 'systemctl', 'start', 'wifi-hotspot']).strip().decode('utf-8')
+        except:
+            logging.debug('Wifi hotspot enabling failed')
+
+    def disable_hotspot(self):
+        try:
+            subprocess.check_output(['sudo', 'systemctl', 'stop', 'wifi-hotspot']).strip().decode('utf-8')
+            subprocess.check_output(['sudo', 'systemctl', 'disable', 'wifi-hotspot']).strip().decode('utf-8')
+        except:
+            logging.debug('Wifi hotspot disabling failed')

--- a/modalapistomp.py
+++ b/modalapistomp.py
@@ -126,6 +126,7 @@ def main():
         if handler.lcd is not None:
             handler.lcd.cleanup()
         GPIO.cleanup()
+        del handler
         logging.info("Completed cleanup")
 
 

--- a/pistomp/lcdcolor.py
+++ b/pistomp/lcdcolor.py
@@ -85,9 +85,9 @@ class Lcdcolor(lcdbase.Lcdbase):
     def update_wifi(self, wifi_status):
         if not self.supports_toolbar:
             return
-        if util.DICT_GET(wifi_status, 'hotspot_active') == '1':
+        if util.DICT_GET(wifi_status, 'hotspot_active'):
             img = "wifi_orange.png"
-        elif util.DICT_GET(wifi_status, 'wifi_connected') == '1':
+        elif util.DICT_GET(wifi_status, 'wifi_connected'):
             img = "wifi_silver.png"
         else:
             img = "wifi_gray.png"


### PR DESCRIPTION
This removes reliance on the patchbox CLI which is very slow and was only
called occasionally.

Instead, we have our own implementation to query the wifi state more
directly (much faster), running from a separate thread as to avoid
affecting the UI responsiveness.

This allows us to keep a "live" status that is properly updated when
things change from outside of pi-stomp control. This also cuts a few
seconds from pi-stomp startup time (patchbox CLI is that slow).

The next step is probably to have our own UI for configuring the wifi
but that is for another day :-) We probably want to do some serious
UI cleanup work before we do any drastic change such as implementing
an encoder-driven keyboard...

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>