### PR TITLE
[RFC] pistomp v1: Fix footswitch hardware test

### DIFF
--- a/pistomp/pistomp.py
+++ b/pistomp/pistomp.py
@@ -147,6 +147,7 @@ class Pistomp(hardware.Hardware):
                 timeout = 1000  # 10 seconds
                 initial_value = GPIO.input(f[2])
                 while self.test_pass is False and timeout > 0:
+                    fs.poll()
                     new_value = GPIO.input(f[2])  # Verify that LED pin toggles
                     if new_value is not initial_value:
                         break
@@ -240,5 +241,5 @@ class Pistomp(hardware.Hardware):
             GPIO.cleanup()
             sys.exit()
 
-    def test_passed(self, data):
+    def test_passed(self, data = None):
         self.test_pass = True


### PR DESCRIPTION
NOTE: I don't have a v1 to test, this is based on copying some of that test code into pistompcore.py
and hard wiring the setup. Hopefully that's all that is broken.

test_passed can be called without argument and we need to poll
the footswitch to get events

Signed-off-by: Benjamin Herrenschmidt <benh@kernel.crashing.org>