### PR TITLE
remove dependency on outdated RPi.version lib

### DIFF
--- a/pistomp/ledstrip.py
+++ b/pistomp/ledstrip.py
@@ -16,7 +16,7 @@
 import _rpi_ws281x as ws
 from rpi_ws281x import PixelStrip
 import matplotlib
-import RPi.version
+import re
 from PIL import ImageColor
 
 import common.util as Util
@@ -30,9 +30,13 @@ LED_BRIGHTNESS = 30  # Set to 0 for darkest and 255 for brightest
 LED_INVERT = False    # True to invert the signal (when using NPN transistor level shift)
 LED_CHANNEL = 1      # set to '1' for GPIOs 13, 19, 41, 45 or 53
 
-LED_DMA = 12          # DMA channel to use for generating signal
-pi_version = RPi.version.info['version']
-if pi_version == 4:
+# DMA channel to use for generating signal
+# Determine DMA channel based on pi model, if we need finer granularity, use the Revision field
+_cpuinfo = open('/proc/cpuinfo').read()
+_info=''.join(_cpuinfo.split())
+_match = re.search(r'(?<=Model:RaspberryPi)\d', _info)
+LED_DMA = 12  # pi3
+if _match and _match.group(0) == "4":
     LED_DMA = 10
 
 

--- a/setup/pkgs/simple_install.sh
+++ b/setup/pkgs/simple_install.sh
@@ -36,7 +36,6 @@ sudo /usr/bin/pip3 install requests
 
 # GPIO
 sudo /usr/bin/pip3 install RPi.GPIO
-sudo /usr/bin/pip3 install RPi.version
 
 #GFXHat
 sudo /usr/bin/pip3 install gfxhat


### PR DESCRIPTION
This should fix issues with pi versions not supported by RPi.version like pi4/8GB, etc.