### PR TITLE
Add support for banks

### DIFF
--- a/common/token.py
+++ b/common/token.py
@@ -16,6 +16,7 @@
 ACTION = 'action'
 ADC_INPUT = 'adc_input'
 ANALOG_CONTROLLERS = 'analog_controllers'
+BANK = 'bank'
 BUNDLE = 'bundle'
 BYPASS = 'bypass'
 CATEGORY = 'category'

--- a/modalapistomp.py
+++ b/modalapistomp.py
@@ -96,6 +96,7 @@ def main():
         handler.add_hardware(hw)
 
         # Load all pedalboard info from the lilv ttl file
+        handler.load_banks()
         handler.load_pedalboards()
 
         # Load the current pedalboard as "current"

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -254,11 +254,20 @@ class Lcd(abstract_lcd.Lcd):
         self.main_panel.add_sel_widget(self.w_preset)
 
     def draw_pedalboard_menu(self, event, widget):
-        bank_pbs = util.DICT_GET(self.handler.get_banks(), self.handler.get_bank())
         items = []
-        for p in self.pedalboards:
-            if bank_pbs is None or p.title in bank_pbs:
+        bank_pbs = util.DICT_GET(self.handler.get_banks(), self.handler.get_bank())
+
+        if bank_pbs is None:
+            # No bank so display all pedalboards as they're stored (alphabetically)
+            for p in self.pedalboards:
                 items.append((p.title, self.handler.pedalboard_change, p))
+        else:
+            # Bank is set so show only those in the bank and in the order defined by the bank
+            for b in bank_pbs:
+                for p in self.pedalboards:  # LAME ugly O(N2) search
+                    if p.title == b:
+                        items.append((p.title, self.handler.pedalboard_change, p))
+
         self.draw_selection_menu(items, "Pedalboards", auto_dismiss=True, dismiss_option=True)
 
     def draw_preset_menu(self, event, widget):

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -254,9 +254,11 @@ class Lcd(abstract_lcd.Lcd):
         self.main_panel.add_sel_widget(self.w_preset)
 
     def draw_pedalboard_menu(self, event, widget):
+        bank_pbs = util.DICT_GET(self.handler.get_banks(), self.handler.get_bank())
         items = []
         for p in self.pedalboards:
-            items.append((p.title, self.handler.pedalboard_change, p))
+            if bank_pbs is None or p.title in bank_pbs:
+                items.append((p.title, self.handler.pedalboard_change, p))
         self.draw_selection_menu(items, "Pedalboards", auto_dismiss=True, dismiss_option=True)
 
     def draw_preset_menu(self, event, widget):
@@ -476,10 +478,18 @@ class Lcd(abstract_lcd.Lcd):
     def draw_system_menu(self, event, widget):
         items = [("System shutdown", self.handler.system_menu_shutdown, None),
                  ("System reboot",  self.handler.system_menu_reboot, None),
+                 ("Bank Select", self.draw_bank_menu, None),
                  ("Save current pedalboard", self.handler.system_menu_save_current_pb, None),
                  ("Reload pedalboards", self.handler.system_menu_reload, None),
                  ("Restart sound engine", self.handler.system_menu_restart_sound, None)]
         self.draw_selection_menu(items, "System Menu")
+
+    def draw_bank_menu(self, event):
+        current_bank = self.handler.get_bank()
+        items = [("None (All pedalboards)", self.handler.set_bank, None, current_bank==None)]
+        for k,v in self.handler.get_banks().items():
+            items.append((k, self.handler.set_bank, k, k==current_bank))
+        self.draw_selection_menu(items, "Bank Select", auto_dismiss=True)
 
     def draw_audio_menu(self, event, widget):
         items = [("Output Volume", self.handler.system_menu_headphone_volume, None),

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -513,9 +513,14 @@ class Lcd(abstract_lcd.Lcd):
         self.draw_selection_menu(items, "Audio Menu") 
 
     def draw_audio_parameter_dialog(self, name, symbol, value, min, max, commit_callback):
+        d = util.DICT_GET(self.w_parameter_dialogs, symbol)
+        if d is not None and d.parent is not None:
+            return d
+
         d = Parameterdialog(self.pstack, name, value, min, max,
-                            width=270, height=130, auto_destroy=False, title=name, timeout=2.2,
+                            width=270, height=130, auto_destroy=True, title=name, timeout=2.2,
                             action=commit_callback, object=symbol, taper=1)
+        self.w_parameter_dialogs[symbol] = d
         self.pstack.push_panel(d)
         return d
 


### PR DESCRIPTION
Banks are pedalboard collection sets.   By default no bank is set, so the pedalboard selection menu will show all pedalboards on the system.   The user can create banks via the MOD-UI.  A bank can be selected via System Menu > Bank Select.  Then, only the pedalboards contained in the selected bank will be available for selection on the LCD.  The bank preference is stored in the settings file (~/data/config/settings.yml).  Any changes to the banks via the MOD-UI will be detected by a pi-stomp file watcher (~/data/banks.json) and reloaded.  