### PR TITLE
Initial updates for Wifi in bookworm

### DIFF
--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -138,7 +138,7 @@ class WifiManager():
             'ifname', 'wlan0'
         ], check=True)
 
-    def get_wifi_name():
+    def get_wifi_name(self):
         try:
             # Run nmcli command to get connected wifi name
             result = subprocess.run(['nmcli', '-t', '-f', 'NAME', 'connection', 'show', '--active'], capture_output=True, text=True)

--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -126,3 +126,22 @@ class WifiManager():
             subprocess.check_output(['sudo', 'systemctl', 'disable', 'wifi-hotspot']).strip().decode('utf-8')
         except:
             logging.debug('Wifi hotspot disabling failed')
+
+    def configure_wifi(ssid, password):
+        # Disconnect from any connected network
+        subprocess.run(['nmcli', 'device', 'disconnect', 'wlan0'], check=True)
+    
+        # Add a new WiFi connection with the provided SSID and password
+        subprocess.run([
+            'nmcli', 'device', 'wifi', 'connect', ssid,
+            'password', password,
+            'ifname', 'wlan0'
+        ], check=True)
+
+    def get_wifi_name():
+        try:
+            # Run nmcli command to get connected wifi name
+            result = subprocess.run(['nmcli', '-t', '-f', 'NAME', 'connection', 'show', '--active'], capture_output=True, text=True)
+            
+            # Extract the wifi name from the output
+            wifi_name = result.stdout.strip()

--- a/setup/services/hotspot/usr/lib/pistomp-wifi/disable_wifi_hotspot.sh
+++ b/setup/services/hotspot/usr/lib/pistomp-wifi/disable_wifi_hotspot.sh
@@ -24,7 +24,6 @@ if [[ "$(systemctl is-system-running || true)" == "stopping" ]]; then
 fi
 
 rfkill unblock wifi
-dhcpcd --allowinterfaces wlan0
 systemctl stop hostapd
 systemctl stop dnsmasq
 systemctl disable hostapd
@@ -35,4 +34,4 @@ echo 0 > /proc/sys/net/ipv4/ip_forward
 iwlist wlan0 scan > /dev/null 2>&1
 ifconfig wlan0 up
 systemctl restart avahi-daemon
-wpa_cli -i wlan0 reconnect
+nmcli device connect wlan0

--- a/setup/services/hotspot/usr/lib/pistomp-wifi/enable_wifi_hotspot.sh
+++ b/setup/services/hotspot/usr/lib/pistomp-wifi/enable_wifi_hotspot.sh
@@ -20,8 +20,7 @@
 #
 
 rfkill unblock wifi
-wpa_cli -i wlan0 disconnect
-dhcpcd --denyinterfaces wlan0
+nmcli device disconnect wlan0
 ifconfig wlan0 down
 ifconfig wlan0 172.24.1.1 netmask 255.255.255.0 broadcast 172.24.1.255
 systemctl stop dnsmasq


### PR DESCRIPTION
This updates the hotspot code to use nmcli instead of wpa_cli and dhcpd. It also adds the base connections routines for the wifi connection via ui.