### PR TITLE
Pi5 Eeprom update script

### DIFF
--- a/util/pi5_eeprom_update.sh
+++ b/util/pi5_eeprom_update.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# This file is part of pi-stomp.
+#
+# pi-stomp is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# pi-stomp is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
+
 # Temporary file for EEPROM configuration
 TEMP_CONFIG="/tmp/eeprom_config.txt"
 

--- a/util/pi5_eeprom_update.sh
+++ b/util/pi5_eeprom_update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Temporary file for EEPROM configuration
+TEMP_CONFIG="/tmp/eeprom_config.txt"
+
+# Extract the current EEPROM configuration
+sudo rpi-eeprom-config > "$TEMP_CONFIG"
+
+# Update the configuration
+if grep -q "^POWER_OFF_ON_HALT=" "$TEMP_CONFIG"; then
+    # Update the existing line
+    sudo sed -i 's/^POWER_OFF_ON_HALT=.*/POWER_OFF_ON_HALT=1/' "$TEMP_CONFIG"
+else
+    # Add the setting if it doesn't exist
+    sudo echo "POWER_OFF_ON_HALT=1" >> "$TEMP_CONFIG"
+fi
+
+# Write the updated configuration back
+sudo rpi-eeprom-config --apply "$TEMP_CONFIG"
+
+# Clean up
+sudo rm "$TEMP_CONFIG"


### PR DESCRIPTION
This is to allow the pi5 to deep sleep and turn off the gpio and 3.3v rail, which turns off the display when shutting down with either the power button or the shutdown menu item. This might also work on pi4, but I don't have a pi4 to test on currently. It's only really helpful on pi4 to see that the device is completely shutdown.