### PR TITLE
Prevent crashes when update_bypass is called too early

### DIFF
--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -652,6 +652,8 @@ class Lcd(abstract_lcd.Lcd):
         pass
 
     def update_bypass(self, bypass_left, bypass_right):
+        if self.w_power is None:
+            return
         if not bypass_left and not bypass_right:
             img = 'power_green.png'
         elif not bypass_left:


### PR DESCRIPTION
I got a crash on changing pedalboards that said `self.w_power` was `None` -- caused by `update_bypass` being called before the power icon had been (re-)created.