### PR TITLE
Only pop the main panel if it was actually pushed

### DIFF
--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -624,7 +624,8 @@ class Lcd(abstract_lcd.Lcd):
     def cleanup(self):
         self.pstack.pop_panel(None)  # current panel
         self.pstack.pop_panel(self.footswitch_panel)
-        self.pstack.pop_panel(self.main_panel)
+        if self.main_panel_pushed:
+            self.pstack.pop_panel(self.main_panel)
         self.w_splash.set_foreground(self.color_splash_down)
         self.splash_panel.refresh()
     


### PR DESCRIPTION
Fixes a bug I was seeing when rapidly switching between tweak encoders and volume changing.