### PR TITLE
Ensure analog inputs can reach their ends

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -151,6 +151,7 @@ Shortpress accepts string (callback name) or object with `callback` and `args` (
 - **Direct hardware access** - No HAL layer, direct SPI/GPIO/MIDI interaction
 - **Real-time constraints** - Never block in critical path, separate frequencies by priority
 - **Hardware reality drives architecture** - Embrace limitations (ADC polling, SPI timing)
+- **ADC endpoint clamping** - Ensure full range of inputs is not prevented by hysteresis
 
 ### Version Handling
 - **Explicit version routing** - Factory pattern with known version checks, not capability detection

--- a/pistomp/analogmidicontrol.py
+++ b/pistomp/analogmidicontrol.py
@@ -60,7 +60,7 @@ class AnalogMidiControl(analogcontrol.AnalogControl):
             return
 
         # read the analog pin
-        value = self.readChannel()
+        value = self._clamp_endpoints(self.readChannel())
         set_volume = as_midi_value(value)
 
         cc = [self.midi_channel | CONTROL_CHANGE, self.midi_CC, set_volume]
@@ -70,10 +70,22 @@ class AnalogMidiControl(analogcontrol.AnalogControl):
         # save the reading to prevent duplicate sends on next poll
         self.last_read = value
 
+    def _clamp_endpoints(self, value: int) -> int:
+        """Clamp ADC values within tolerance of endpoints to exact endpoints.
+
+        Creates a deadband at both extremes so the control always reaches
+        exactly 0 and 1023, with natural hysteresis at the tolerance boundary.
+        """
+        if value <= self.tolerance:
+            return 0
+        if value >= 1023 - self.tolerance:
+            return 1023
+        return value
+
     @override
     def refresh(self):
         # read the analog pin
-        value = self.readChannel()
+        value = self._clamp_endpoints(self.readChannel())
 
         # how much has it changed since the last read?
         pot_adjust = abs(value - self.last_read)


### PR DESCRIPTION
The tolerance deadband (used to suppress jitter near the center; hysteresis) also prevented the ADC from ever reporting exactly 0 or 1023 at the extremes. Expression pedals couldn't reach their full range — they'd always stop a few counts short of the endpoints.

This was especially observable when e.g. an expression pedal was moving quickly.