### PR TITLE
Pillow dependency and 10+ compatbility

### DIFF
--- a/pistomp/lcd128x64.py
+++ b/pistomp/lcd128x64.py
@@ -247,8 +247,9 @@ class Lcd(ABC):
         self.erase_zone(0)
 
         #pedalboard = pedalboard.lower().capitalize()
-        pb_size  = self.title_font.getsize(pedalboard)[0]
-        font_height = self.title_font.getsize(pedalboard)[1]
+        pb_bbox = self.title_font.getbbox(pedalboard)
+        pb_size  = pb_bbox[2] - pb_bbox[0]
+        font_height = pb_bbox[3]
         y = -2  # negative pushes text to top of LCD
 
         # Pedalboard Name
@@ -265,8 +266,10 @@ class Lcd(ABC):
 
             # Preset Name
             #preset = preset.lower().capitalize()
-            pre_size = self.title_font.getsize(preset)[0]
-            x = x + self.title_font.getsize(delimiter)[0]
+            pre_bbox = self.title_font.getbbox(preset)
+            pre_size = pre_bbox[2] - pre_bbox[0]
+            delim_bbox = self.title_font.getbbox(delimiter)
+            x = x + delim_bbox[2] - delim_bbox[0]
             x2 = x + pre_size
             y2 = font_height
             if invert_pre:
@@ -438,7 +441,8 @@ class Lcd(ABC):
         text = ""
         for x in name.lower().replace('_', '').replace('/', '').replace(' ', ''):
             test = text + x
-            test_size = self.small_font.getsize(test)[0]
+            test_bbox = self.small_font.getbbox(test)
+            test_size = test_bbox[2] - test_bbox[0]
             if test_size >= width:
                 break
             text = test

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -774,7 +774,8 @@ class Lcd(abstract_lcd.Lcd):
         text = ""
         for x in name.lower().replace('_', '').replace('/', '').replace(' ', ''):
             test = text + x
-            test_size = self.small_font.getsize(test)[0]
+            test_bbox = self.small_font.getbbox(test)
+            test_size = test_bbox[2] - test_bbox[0]
             if test_size >= width:
                 break
             text = test

--- a/pistomp/lcdbase.py
+++ b/pistomp/lcdbase.py
@@ -111,8 +111,9 @@ class Lcdbase(abstract_lcd.Lcd):
             self.zone_y[i] = y_offset
 
     def base_draw_title(self, draw, font, pedalboard, preset, invert_pb, invert_pre, highlight_only=False):
-        pb_size  = font.getsize(pedalboard)[0]
-        font_height = font.getsize(pedalboard)[1]
+        pb_bbox = font.getbbox(pedalboard)
+        pb_size  = pb_bbox[2] - pb_bbox[0]
+        font_height = pb_bbox[3]
         x0 = self.left
         y = self.top  # negative pushes text to top of LCD
         highlight_color = self.highlight
@@ -134,8 +135,10 @@ class Lcdbase(abstract_lcd.Lcd):
             draw.text((x, y), delimiter, self.foreground, font)
 
             # Preset Name
-            pre_size = font.getsize(preset)[0]
-            x = x + font.getsize(delimiter)[0]
+            pre_bbox = font.getbbox(preset)
+            pre_size = pre_bbox[2] - pre_bbox[0]
+            delim_bbox = font.getbbox(delimiter)
+            x = x + delim_bbox[2] - delim_bbox[0]
             x2 = x + pre_size
             y2 = font_height
             if invert_pre:
@@ -210,7 +213,8 @@ class Lcdbase(abstract_lcd.Lcd):
         text = ""
         for x in name.lower().replace('_', '').replace('/', '').replace(' ', ''):
             test = text + x
-            test_size = self.small_font.getsize(test)[0]
+            test_bbox = self.small_font.getbbox(test)
+            test_size = test_bbox[2] - test_bbox[0]
             if test_size >= width:
                 break
             text = test

--- a/pistomp/lcdgfx.py
+++ b/pistomp/lcdgfx.py
@@ -275,8 +275,9 @@ class Lcd(abstract_lcd.Lcd):
         self.erase_zone(0)
 
         #pedalboard = pedalboard.lower().capitalize()
-        pb_size  = self.title_font.getsize(pedalboard)[0]
-        font_height = self.title_font.getsize(pedalboard)[1]
+        pb_bbox = self.title_font.getbbox(pedalboard)
+        pb_size  = pb_bbox[2] - pb_bbox[0]
+        font_height = pb_bbox[3]
         y = -2  # negative pushes text to top of LCD
 
         # Pedalboard Name
@@ -293,8 +294,10 @@ class Lcd(abstract_lcd.Lcd):
 
             # Preset Name
             #preset = preset.lower().capitalize()
-            pre_size = self.title_font.getsize(preset)[0]
-            x = x + self.title_font.getsize(delimiter)[0]
+            pre_bbox = self.title_font.getbbox(preset)
+            pre_size = pre_bbox[2] - pre_bbox[0]
+            delim_bbox = self.title_font.getbbox(delimiter)
+            x = x + delim_bbox[2] - delim_bbox[0]
             x2 = x + pre_size
             y2 = font_height
             if invert_pre:
@@ -468,7 +471,8 @@ class Lcd(abstract_lcd.Lcd):
         text = ""
         for x in name.lower().replace('_', '').replace('/', '').replace(' ', ''):
             test = text + x
-            test_size = self.small_font.getsize(test)[0]
+            test_bbox = self.small_font.getbbox(test)
+            test_size = test_bbox[2] - test_bbox[0]
             if test_size >= width:
                 break
             text = test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "jsonschema>=4.0",
     "python-rtmidi>=1.4",
     "requests>=2.28",
+    "Pillow>=9.2",
     "pyalsaaudio>=0.9; sys_platform == 'linux'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "jsonschema>=4.0",
     "python-rtmidi>=1.4",
     "requests>=2.28",
-    "Pillow>=9.2",
+    "Pillow>=9.4",
     "pyalsaaudio>=0.9; sys_platform == 'linux'",
 ]
 

--- a/uilib/box.py
+++ b/uilib/box.py
@@ -105,9 +105,11 @@ class Box:
     @property
     def PIL_rect(self):
         """Return rectangle as a tuple with botright coords minus 1
-           to account for PIL/Pillow bug in "rectangle" primitives
+           to account for PIL/Pillow bug in "rectangle" primitives.
+           Clamp so x1 >= x0 and y1 >= y0 (Pillow 10+ rejects degenerate rects).
         """
-        return (self.box[0], self.box[1], self.box[2] - 1, self.box[3] - 1)
+        x0, y0, x1, y1 = self.box
+        return (x0, y0, max(x0, x1 - 1), max(y0, y1 - 1))
 
     @staticmethod
     def xywh(x,y,w,h):

--- a/uilib/dialog.py
+++ b/uilib/dialog.py
@@ -83,7 +83,8 @@ class MessageDialog(Dialog):
     def __init__(self, panelstack, message, title="Error", width=200, height=90):
         super(MessageDialog, self).__init__(width=width, height=height, title=title, auto_destroy=True)
 
-        chars_per_line = width // int(Config().get_font('default_title').getsize("a")[0])
+        bbox = Config().get_font('default_title').getbbox("a")
+        chars_per_line = width // int(bbox[2] - bbox[0])
         chunks = textwrap.wrap(message, width=chars_per_line)
         wrapped = '\n'.join(chunks)
 

--- a/uilib/misc.py
+++ b/uilib/misc.py
@@ -61,7 +61,7 @@ def get_text_size(text_string, font, metrics = None):
     if metrics is not None:
         ascent, descent = metrics
     else:
-        ascent, descent = font.getgmetrics()
+        ascent, descent = font.getmetrics()
 
 #    text_width = font.getmask(text_string).getbbox()[2]
 #    text_height = font.getmask(text_string).getbbox()[3] + descent

--- a/uilib/misc.py
+++ b/uilib/misc.py
@@ -66,7 +66,7 @@ def get_text_size(text_string, font, metrics = None):
 #    text_width = font.getmask(text_string).getbbox()[2]
 #    text_height = font.getmask(text_string).getbbox()[3] + descent
     bbox = font.getbbox(text_string)
-    text_width = bbox[2]
+    text_width = bbox[2] - bbox[0]
     text_height = bbox[3] + descent
 
     return (text_width, text_height)

--- a/uilib/text.py
+++ b/uilib/text.py
@@ -42,7 +42,8 @@ class LetterSelector(Widget):
         cs = self.charsets[mode]
         mw, mh = 0, 0
         for c in cs:
-            w, h = self.font.getsize(c)
+            bbox = self.font.getbbox(c)
+            w, h = bbox[2] - bbox[0], bbox[3]
             mw = max(mw,w)
             mh = max(mh,h)
         self.l_w = mw
@@ -128,7 +129,8 @@ class TextEditor(RoundedPanel):
         self.outline = 2
         self.curline = widget.text
         self.font = ImageFont.truetype("DejaVuSans.ttf", 18)
-        msg_w, msg_h = self.font.getsize(widget.edit_message)
+        bbox = self.font.getbbox(widget.edit_message)
+        msg_w, msg_h = bbox[2] - bbox[0], bbox[3]
         msg_box = Box.xywh(10, 10, msg_w, msg_h)
         self.msg = TextWidget(box = msg_box, text = widget.edit_message, font = self.font, parent = self)
         edit_box = Box.xywh(10,30,280,20)

--- a/uilib/text.py
+++ b/uilib/text.py
@@ -231,6 +231,8 @@ class TextWidget(Widget):
         super(TextWidget,self)._adjust_box()
 
     def set_text(self, text):
+        if self.text == text:
+            return
         self.text = text
         self.text_size_valid = False
         self.refresh()


### PR DESCRIPTION
* added pillow to `pyproject.toml` (>= 9.4, which is what is currently used)
* moved from `getsize` to `getbbox` (former was deprecated)
* fix for degenerate rectangles causing problems in Pillow 10+
* micro-optimization: do not refresh text if we set it to the same string

#### Branch stack
* https://github.com/TreeFallSound/pi-stomp/pull/130
  * https://github.com/sastraxi/pi-stomp/pull/16