### PR TITLE
Move and extend `Parameter` to `common/`

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -414,7 +414,7 @@ poll_controls()
 
 **MOD API**:
 - `modalapi/pedalboard.py` - LILV parser
-- `modalapi/parameter.py` - Parameter representation
+- `common/parameter.py` - Parameter representation & formatting
 - `modalapi/plugin.py` - Plugin representation
 
 **Config & State**:

--- a/common/parameter.py
+++ b/common/parameter.py
@@ -50,6 +50,10 @@ class Parameter:
         self.type = Type.DEFAULT
         self.enum_values = []
 
+        units_info = util.DICT_GET(plugin_info, 'units')
+        self.unit_symbol = util.DICT_GET(units_info, 'symbol') if units_info else None
+        self.unit_label = util.DICT_GET(units_info, 'label') if units_info else None
+
         properties = util.DICT_GET(plugin_info, TTL_PROPERTIES)
         if properties is not None and len(properties) > 0:
             if TTL_ENUMERATION in properties:
@@ -70,7 +74,18 @@ class Parameter:
             ret.append((util.DICT_GET(v,'label'), util.DICT_GET(v,'value')))
         return ret
 
+    def get_taper(self):
+        return 2 if self.type == Type.LOGARITHMIC else 1
+
+    def format(self, value):
+        if self.type == Type.INTEGER or self.type == Type.TOGGLED or self.type == Type.ENUMERATION:
+             text = "%d" % round(float(value))
+        else:
+             text = util.format_float(value)
+
+        if self.unit_symbol:
+            text = f"{text} {self.unit_symbol}"
+        return text
+
     def to_json(self):
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
-
-

--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -25,7 +25,7 @@ import common.token as Token
 import common.util as util
 import pistomp.switchstate as switchstate
 import modalapi.pedalboard as Pedalboard
-import modalapi.parameter as Parameter
+import common.parameter as Parameter
 import modalapi.wifi as Wifi
 
 from pistomp.analogmidicontrol import AnalogMidiControl

--- a/modalapi/parameter.py
+++ b/modalapi/parameter.py
@@ -1,0 +1,3 @@
+# Re-export from common.parameter for backward compatibility after rename.
+from common.parameter import *  # noqa: F401, F403
+from common.parameter import Parameter, Type

--- a/modalapi/pedalboard.py
+++ b/modalapi/pedalboard.py
@@ -24,7 +24,7 @@ import urllib.parse
 
 import common.token as Token
 import common.util as util
-import modalapi.parameter as Parameter
+import common.parameter as Parameter
 import modalapi.plugin as Plugin
 
 class Pedalboard:

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -18,7 +18,7 @@ import digitalio
 import logging
 import os
 import common.token as Token
-import modalapi.parameter as Parameter
+import common.parameter as Parameter
 import pistomp.category as Category
 import pistomp.lcd as abstract_lcd
 import pistomp.switchstate as switchstate


### PR DESCRIPTION
`Parameter` was living in `modalapi/` despite being a domain object needed well beyond the MOD API layer. This PR moves it to `common/` and extends it with the unit and taper metadata that later PRs require — so that downstream code can ask a parameter how to display and scale itself rather than repeating that logic at every call site.

- Relocate `modalapi/parameter.py` → `common/parameter.py`
- Add `unit_symbol` / `unit_label` parsing from TTL
- Add `get_taper()` and `format()` methods
- Update all imports across the codebase