### PR TITLE
Replace wpa_cli with nmcli for Arch Linux compatibility

### DIFF
--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -80,7 +80,6 @@ class WifiManager():
         return True
 
     def _get_wpa_status(self, status):
-        # Use NetworkManager instead of wpa_cli for better Arch Linux compatibility
         try:
             result = subprocess.run(
                 ['nmcli', '-t', '-f', 'GENERAL.STATE,GENERAL.CONNECTION,IP4.ADDRESS,802-11-WIRELESS.SSID',
@@ -106,7 +105,7 @@ class WifiManager():
             new_status['wifi_connected'] = connected = self._is_wifi_connected()
             new_status['hotspot_active'] = hp_active = self._is_hotspot_active()
             if supported and (connected or hp_active):
-                self._get_wpa_status(new_status)  # Uses NetworkManager for status
+                self._get_wpa_status(new_status)
             if new_status != self.last_status:
                 logging.debug("Wifi status changed:" + str(new_status))
                 creds=()

--- a/modalapi/wifi.py
+++ b/modalapi/wifi.py
@@ -80,16 +80,24 @@ class WifiManager():
         return True
 
     def _get_wpa_status(self, status):
+        # Use NetworkManager instead of wpa_cli for better Arch Linux compatibility
         try:
-            text_out = subprocess.check_output(['wpa_cli', '-i', self.iface_name, 'status']).strip().decode('utf-8')
-            for i in text_out.split('\n'):
-                if len(i) == 0:
-                    continue
-                (key, value) = i.split('=')
-                if key and value:
-                    status[key] = value
+            result = subprocess.run(
+                ['nmcli', '-t', '-f', 'GENERAL.STATE,GENERAL.CONNECTION,IP4.ADDRESS,802-11-WIRELESS.SSID',
+                 'device', 'show', self.iface_name],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            if result.returncode == 0:
+                for line in result.stdout.strip().split('\n'):
+                    if ':' in line:
+                        key, value = line.split(':', 1)
+                        # Map nmcli fields to wpa_cli-like keys for compatibility
+                        key = key.strip().replace('GENERAL.', '').replace('802-11-WIRELESS.', '').replace('.', '_').lower()
+                        status[key] = value.strip()
         except Exception as e:
-            logging.error("WPA CLI fail:" + str(e))
+            logging.error("NetworkManager status fail:" + str(e))
 
     def _polling_thread(self):
         while True:
@@ -98,7 +106,7 @@ class WifiManager():
             new_status['wifi_connected'] = connected = self._is_wifi_connected()
             new_status['hotspot_active'] = hp_active = self._is_hotspot_active()
             if supported and (connected or hp_active):
-                self._get_wpa_status(new_status)  # TODO replace this with an NetworkManager equivalent status
+                self._get_wpa_status(new_status)  # Uses NetworkManager for status
             if new_status != self.last_status:
                 logging.debug("Wifi status changed:" + str(new_status))
                 creds=()


### PR DESCRIPTION
Arch doesn't have `wpa_supplicant`, but we already depend on `nmcli`, so we can just replace the call with an equivalent one using that binary. Works on pi-gen-pistomp too.