### PR TITLE
Skip LCD clear and splash on startup when OS provides a splash screen

### DIFF
--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -108,15 +108,16 @@ class Lcd(abstract_lcd.Lcd):
         # panels
         self.pstack = PanelStack(display, image_format='RGB', use_dimming=True)  # TODO use dimming without loosing FS's
         self.splash_panel = Panel(box=Box.xywh(0, 0, self.display_width, self.display_height))
-        self.pstack.push_panel(self.splash_panel)
+        self.pstack.push_panel(self.splash_panel, refresh=False)
         self.main_panel = Panel(box=Box.xywh(0, 0, self.display_width, 170))
         self.main_panel_pushed = False
         self.footswitch_panel = Panel(box=Box.xywh(0, 176, self.display_width, 64))
-        self.pstack.push_panel(self.footswitch_panel)
+        self.pstack.push_panel(self.footswitch_panel, refresh=False)
 
         self.pedalboards = {}
 
-        self.splash_show(True)
+        if not display.has_system_splash:
+            self.splash_show(True)
 
     #
     # Navigation
@@ -626,9 +627,10 @@ class Lcd(abstract_lcd.Lcd):
         self.pstack.pop_panel(self.footswitch_panel)
         if self.main_panel_pushed:
             self.pstack.pop_panel(self.main_panel)
-        self.w_splash.set_foreground(self.color_splash_down)
-        self.splash_panel.refresh()
-    
+        if self.w_splash is not None:
+            self.w_splash.set_foreground(self.color_splash_down)
+            self.splash_panel.refresh()
+
     def clear(self):
         pass
 

--- a/uilib/lcd_ili9341.py
+++ b/uilib/lcd_ili9341.py
@@ -15,39 +15,52 @@
 
 import adafruit_rgb_display.ili9341 as ili9341
 
-from uilib.panel import *
+from uilib.panel import LcdBase, Box
+from functools import cached_property
 import logging
 import threading
+import os
+
+INIT_STAMP = "/run/lcd.init"
+
 
 class LcdIli9341(LcdBase):
     # XXX
     # TODO: Turn "flip" into all 90deg angle combinations
-    def __init__(self, spi, cs_pin, dc_pin, reset_pin, baudrate, flip = True):
-        self.disp = ili9341.ILI9341(
-            spi,
-            cs=cs_pin,
-            dc=dc_pin,
-            rst=reset_pin,
-            baudrate=baudrate
-        )
+    def __init__(self, spi, cs_pin, dc_pin, reset_pin, baudrate, flip=True):
+        rst = reset_pin if not self.has_system_splash else None
+
+        self.disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=rst, baudrate=baudrate)
+
+        if not self.has_system_splash:
+            self._set_stamp()
 
         # Use this to assure we don't have multiple threads trying to change the screen
         # All methods which do change the screen (eg. dist. calls) should acquire/release
         self.lock = threading.Lock()
-
-        # Clear the display
-        self.clear()
 
         # Test full screen image
         self.width = self.disp.height
         self.height = self.disp.width
         self.flip = flip
 
+    @cached_property
+    def has_system_splash(self):
+        """Does the OS provide a splash screen?"""
+        return os.path.exists(INIT_STAMP)
+
+    def _set_stamp(self):
+        try:
+            with open(INIT_STAMP, "w") as _f:
+                pass
+        except Exception:
+            pass
+
     def dimensions(self):
         return (self.width, self.height)
 
     def default_format(self):
-        return 'RGB'
+        return "RGB"
 
     def clear(self):
         self.lock.acquire()
@@ -67,7 +80,7 @@ class LcdIli9341(LcdBase):
         #
         img_width, img_height = image.size
         if box is None:
-            box = Box(0,0,img_width,img_height)
+            box = Box(0, 0, img_width, img_height)
 
         # Check if we need to crop the image to the LCD size
         x1, y1, x2, y2 = box.rect
@@ -76,7 +89,7 @@ class LcdIli9341(LcdBase):
         if y2 > self.height:
             y2 = self.height
         if x1 != 0 or y1 != 0 or x2 != img_width or y2 != img_width:
-            image = image.crop((x1,y1,x2,y2))
+            image = image.crop((x1, y1, x2, y2))
             if self.flip:
                 x = self.height - y2
                 y = x1

--- a/uilib/lcd_ili9341.py
+++ b/uilib/lcd_ili9341.py
@@ -32,12 +32,13 @@ class LcdIli9341(LcdBase):
 
         self.disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=rst, baudrate=baudrate)
 
-        if not self.has_system_splash:
-            self._set_stamp()
-
         # Use this to assure we don't have multiple threads trying to change the screen
         # All methods which do change the screen (eg. dist. calls) should acquire/release
         self.lock = threading.Lock()
+
+        if not self.has_system_splash:
+            self.clear()
+            self._set_stamp()
 
         # Test full screen image
         self.width = self.disp.height

--- a/uilib/panel.py
+++ b/uilib/panel.py
@@ -246,7 +246,7 @@ class PanelStack(ContainerWidget):
     def _get_stack(self):
         return self
 
-    def push_panel(self, panel):
+    def push_panel(self, panel, refresh=True):
         assert panel not in self.stack
         assert isinstance(panel, Panel)
 
@@ -257,7 +257,8 @@ class PanelStack(ContainerWidget):
         # Input target
         self.current = panel
         panel.show(refresh = False)
-        self.refresh()
+        if refresh:
+            self.refresh()
 
     def pop_panel(self, panel):
         # panel == None is a special case meaning just pop the current panel


### PR DESCRIPTION
On Arch Linux the boot splash is already visible when pi-stomp starts; clearing the display causes a visible black flash.

The 320x240 LCD now checks for a stamp file (`/run/lcd.init`):

* if absent, it writes it and resets the display normally
* if present it skips the reset/clear

The LCD code also skips `splash_show()` when the display reports has_system_splash. `panel.py` gets push_panel(refresh=False) so the initial panel pushes don't trigger a redundant repaint.