### PR TITLE
First boot: try both main and master for pedalboard git checkout

### DIFF
--- a/util/modify_version.sh
+++ b/util/modify_version.sh
@@ -41,8 +41,8 @@ cp $default_hwfile $hwfile
 if awk "BEGIN {exit !($1 >= 3.0 )}"; then
     cp $pistomp_tre_config_file $config_file
     sudo sed -i 's/-p [0-9]\+/-p 128/' $jackdrc_file
-    if ! git -C "$pb_dir" checkout master; then
-      echo "Git checkout failed"
+    if ! git -C "$pb_dir" checkout master 2>/dev/null && ! git -C "$pb_dir" checkout main 2>/dev/null; then
+      echo "Git checkout failed (tried master and main)"
       exit 1
     fi
 elif awk "BEGIN {exit !($1 >= 2.0 )}"; then


### PR DESCRIPTION
@rreichenbach your call if this is useful -- I set up my pedalboards repo with `main` as the primary branch, so this helps the built-in first boot configuration.