### PR TITLE
Simpler and more correct raspberry pi dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
-        run: uv python install
+        run: uv python install 3.11
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libasound2-dev libjack-dev pkg-config
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --group dev --python 3.11
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run --python 3.11 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-rtmidi>=1.4",
     "requests>=2.28",
     "Pillow>=9.4",
+    "numpy>=2.4",
     "pyalsaaudio>=0.9; sys_platform == 'linux'",
     "websockets>=15.0.1",
     "gpiozero>=2.0; sys_platform == 'linux'",
@@ -77,7 +78,6 @@ pythonVersion = "3.11"
 
 [dependency-groups]
 dev = [
-    "numpy>=2.4.1",
     "pillow>=12.0.0",
     "pyright>=1.1.408",
     "pytest>=9.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ hardware = [
     "lgpio>=0.2; sys_platform == 'linux'",
     "rpi-lgpio>=0.4; sys_platform == 'linux'",
     "spidev>=3.0; sys_platform == 'linux'",
+    "Adafruit-Blinka-Raspberry-Pi5-Neopixel>=1.0.0rc2; sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 
 [project.urls]
@@ -58,6 +59,13 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["modalapi", "pistomp", "uilib", "ui", "common"]
+
+[tool.uv]
+# cap1xxx (via gfxhat) declares rpi-gpio as a dep, but rpi-gpio's sdist
+# only builds on a real Pi with cp311. We satisfy the RPi.GPIO import at
+# runtime via rpi-lgpio (already in [hardware]), so suppress the resolver
+# from ever pulling rpi-gpio in.
+override-dependencies = ["rpi-gpio ; sys_platform == 'never'"]
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[manifest]
+overrides = [{ name = "rpi-gpio", marker = "sys_platform == 'never'" }]
+
 [[package]]
 name = "adafruit-blinka"
 version = "8.68.1"
@@ -17,6 +20,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/15/e452ca7e9f8c25e42d97c32b5a548324d978397648c674b7f7f2ad1ea0ce/adafruit_blinka-8.68.1.tar.gz", hash = "sha256:81808f5b5a16cbb880bf3617907888d105877b479e84318859e011477b889b34", size = 923629, upload-time = "2025-12-18T23:01:15.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/18/c63c058b747df9b47393f30d368c67dd433b1ea4e240715515981591c17f/adafruit_blinka-8.68.1-py3-none-any.whl", hash = "sha256:3f373706b2fde0d470152e3e04976af03fedceebea21451b7cbae4d5dd5c460d", size = 1055124, upload-time = "2025-12-18T23:01:13.846Z" },
+]
+
+[[package]]
+name = "adafruit-blinka-raspberry-pi5-neopixel"
+version = "1.0.0rc2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/71/b200a30082261d5fd5213d9078bacc433cd2b1a0d56ef82c0e11b11441a9/adafruit_blinka_raspberry_pi5_neopixel-1.0.0rc2.tar.gz", hash = "sha256:1faa48461020ba7e55a0b6f0b4e8dc4cd048571c118a7ed2710a9de33f90cbeb", size = 54592, upload-time = "2025-01-23T14:02:22.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/63/8208062a274e3a7b7f1b39ac7c94382125849f9ae93c4198c37acecaa616/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b6ddcfcda2f64231913328b17190e4ed65b65ad459c9a6e9a698e77761663c2", size = 79765, upload-time = "2025-01-23T14:02:13.625Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f5/66f00ded0a49506a4132dc618eda773b09cccbbc47099e99f66cdf6ad06d/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp311-cp311-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9f9fad9aa23c90e73779f857dd9f6c1a920f7f32865ee269394b8fc2ef8ffd0c", size = 72223, upload-time = "2025-01-23T14:02:15.208Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a9/7e0bfaf6487d109ac2e124ed435e402f2a1bdaba4bb3541603b7dbe50b8b/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:734b10ea60940caa40398f80699261a4b5606e1829595d99a2dcff7c2b739e60", size = 79856, upload-time = "2025-01-23T14:02:16.257Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e0/8d9ef24c35d966edae08171014ebfc537d0eb7a9b6f8482462d495310d85/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp312-cp312-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cea6ae40ba8b250a80c48065d440b93916282858748ddd9b00a77f5de250b2ed", size = 71221, upload-time = "2025-01-23T14:02:17.917Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d4/e637b0ac2a84b0b71fb4cd2fd7c54c0706f1b9a1ae9a029e666edd306fea/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eacec8eb4ce6cd3f10073668dca8549b93bf0b57831cc0e350d2e9de594c7967", size = 80786, upload-time = "2025-01-23T14:02:19.471Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d9/b86c4d9a0679feb7f7b72362ac48248ba5cf5d1a3154faa8b72ecc642e28/Adafruit_Blinka_Raspberry_Pi5_Neopixel-1.0.0rc2-cp313-cp313-manylinux_2_24_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cb10e650a4bf8cc5e2a154d0c1fc23a92ce2a6e308c6c3187ec98cb7e48e529c", size = 71170, upload-time = "2025-01-23T14:02:21.046Z" },
 ]
 
 [[package]]
@@ -166,9 +183,6 @@ wheels = [
 name = "cap1xxx"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "rpi-gpio" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/05/5c/a35e94423c6db150645afe54b8cbcabb618ffc9dd120906e45993be10348/Cap1xxx-0.1.4.tar.gz", hash = "sha256:31a326ebc26e670167c8ad25dfca3376e0a53ebfce94b06edd2594afec50ea9e", size = 8793, upload-time = "2021-11-09T12:55:27.747Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/c6/5cebf75ed95358c75f989c67be99263a305d46da827c5f3c1fa54a1ed9d0/Cap1xxx-0.1.4-py3-none-any.whl", hash = "sha256:ddebfc784ffb42a5b2c173e1a6e814fe011da76db92047d328df153644287969", size = 8203, upload-time = "2021-11-09T12:55:26.575Z" },
@@ -862,6 +876,7 @@ dependencies = [
 
 [package.optional-dependencies]
 hardware = [
+    { name = "adafruit-blinka-raspberry-pi5-neopixel", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
     { name = "adafruit-circuitpython-mcp3xxx" },
     { name = "adafruit-circuitpython-neopixel" },
     { name = "adafruit-circuitpython-rgb-display" },
@@ -885,6 +900,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adafruit-blinka-raspberry-pi5-neopixel", marker = "platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'hardware'", specifier = ">=1.0.0rc2" },
     { name = "adafruit-circuitpython-mcp3xxx", marker = "extra == 'hardware'", specifier = ">=1.4" },
     { name = "adafruit-circuitpython-neopixel", marker = "extra == 'hardware'", specifier = ">=6.3" },
     { name = "adafruit-circuitpython-rgb-display", marker = "extra == 'hardware'", specifier = ">=3.10" },
@@ -1330,12 +1346,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
-
-[[package]]
-name = "rpi-gpio"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/0f/10b524a12b3445af1c607c27b2f5ed122ef55756e29942900e5c950735f2/RPi.GPIO-0.7.1.tar.gz", hash = "sha256:cd61c4b03c37b62bba4a5acfea9862749c33c618e0295e7e90aa4713fb373b70", size = 29090, upload-time = "2022-02-06T15:15:06.022Z" }
 
 [[package]]
 name = "rpi-lgpio"

--- a/uv.lock
+++ b/uv.lock
@@ -851,6 +851,7 @@ source = { editable = "." }
 dependencies = [
     { name = "gpiozero", marker = "sys_platform == 'linux'" },
     { name = "jsonschema" },
+    { name = "numpy" },
     { name = "pillow" },
     { name = "pyalsaaudio", marker = "sys_platform == 'linux'" },
     { name = "python-rtmidi" },
@@ -874,7 +875,6 @@ hardware = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "numpy" },
     { name = "pillow" },
     { name = "pyright" },
     { name = "pytest" },
@@ -893,6 +893,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "lgpio", marker = "sys_platform == 'linux' and extra == 'hardware'", specifier = ">=0.2" },
     { name = "matplotlib", marker = "extra == 'hardware'", specifier = ">=3.5" },
+    { name = "numpy", specifier = ">=2.4" },
     { name = "pillow", specifier = ">=9.4" },
     { name = "pyalsaaudio", marker = "sys_platform == 'linux'", specifier = ">=0.9" },
     { name = "python-rtmidi", specifier = ">=1.4" },
@@ -907,7 +908,6 @@ provides-extras = ["hardware"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "numpy", specifier = ">=2.4.1" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
A few things:

1. Uses `--python 3.11` in the test workflow for better test/prod parity
2. Moves `numpy` to be a prod dependency. not a dev one (used in the parameter dialog)
3. Adds Adafruit-Blinka-Raspberry-Pi5-Neopixel (missed this dep before)
4. Deals with the rpi-gpio / rpi-lgpio hack at the uv level rather than requiring the image builder to deal with it

That last one needs a bit more explanation, so I added a comment.