### PR TITLE
Fix: plugin bypass states wrong on initial pedalboard load

### DIFF
--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -582,6 +582,10 @@ class Mod(Handler):
         # Initialize the data
         self.bind_current_pedalboard()
         self.load_current_presets()
+
+        # ensure plugin states (like bypass) are correct on preset change
+        self.preset_change_plugin_update()
+
         self.update_lcd()
 
         # Selection info

--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -438,6 +438,10 @@ class Modhandler(Handler):
         # Initialize the data and draw on LCD
         self.bind_current_pedalboard()
         self.load_current_presets()
+
+        # ensure plugin states (like bypass) are correct on preset change
+        self.preset_change_plugin_update()
+
         self.lcd.link_data(self.pedalboard_list, self.current, self.hardware.footswitches)
         self.lcd.draw_main_panel()
         self.lcd.update_wifi(self.wifi_status)

--- a/tests/v3/test_bypass_sync.py
+++ b/tests/v3/test_bypass_sync.py
@@ -1,0 +1,48 @@
+"""Verify that plugin bypass states are synced from MOD after pedalboard load.
+
+On boot, LILV parses the TTL bundle which stores the "Default" snapshot's bypass
+values.  If MOD is actually running a different snapshot (e.g. tremolo is engaged
+in "TremDly" but bypassed in "Default"), the initial LILV values are wrong.
+set_current_pedalboard() must call preset_change_plugin_update() to reconcile.
+"""
+
+from unittest.mock import MagicMock
+
+from tests.types import SystemFixture
+
+
+def test_v3_bypass_synced_from_mod_on_pedalboard_load(v3_system: SystemFixture, make_plugin):
+    """After set_current_pedalboard(), plugin bypass reflects MOD state, not LILV defaults."""
+    handler = v3_system.handler
+    hw = v3_system.hw
+    mock_get = v3_system.mock_get
+
+    assert handler.current
+
+    # Plugin parsed from TTL as bypassed (Default snapshot), but MOD says it's active
+    plugin = make_plugin("tremolo", bypassed=True)
+    handler.current.pedalboard.plugins = [plugin]
+    handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
+    handler.lcd.draw_main_panel()
+
+    assert plugin.is_bypassed(), "sanity check: plugin starts bypassed (LILV default)"
+
+    def get_side_effect(url, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        if "pi_stomp_get" in url and "/:bypass" in url:
+            resp.text = "false"
+        elif "snapshot/list" in url:
+            resp.text = '{"0": "Default", "1": "TremDly"}'
+        elif "snapshot/name" in url:
+            resp.text = '{"name": "TremDly"}'
+        else:
+            resp.text = "{}"
+        return resp
+
+    mock_get.side_effect = get_side_effect
+
+    pb = handler.pedalboards[list(handler.pedalboards.keys())[0]]
+    handler.set_current_pedalboard(pb)
+
+    assert not plugin.is_bypassed(), "plugin should reflect MOD state (engaged), not LILV default (bypassed)"


### PR DESCRIPTION
Low-priority bugfix.

On boot, pi-Stomp loads plugin bypass values from the LILV-parsed TTL bundle, which reflects the Default snapshot. If MOD is running a different snapshot when the service starts (e.g. because the pi-stomp service crasehd), these values are stale; footswitch LEDs show the wrong state until the user switches presets.

Heres how this happens:

1. set_current_pedalboard() calls
2. bind_current_pedalboard() (LILV defaults) then
3. load_current_presets()

This last method figures out which snapshot is active, but never syncs the actual bypass states back from MOD. preset_change() already does this sync via preset_change_plugin_update(), so the fix is simply to call it on initial load. We add a regression test as well.