### PR TITLE
Simplify deploy script + make it work with PKGBUILDs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ DEST="/home/pistomp/pi-stomp"
 #   new world: ~/pi-stomp is a symlink to the root-owned, pacman-packaged
 #              /opt/pistomp/pi-stomp tree                  -> rsync via `sudo rsync`
 # Detect which one we're on and only elevate if the target is a symlink.
-RSYNC_OPTS=(-az)
+RSYNC_OPTS=(-az --exclude='__pycache__/' --exclude='*.pyc')
 SUDO=""
 if ssh "${HOST}" "test -L ${DEST}"; then
     echo "Detected packaged layout (~/pi-stomp is a symlink); writing with sudo on device."
@@ -17,26 +17,17 @@ if ssh "${HOST}" "test -L ${DEST}"; then
     SUDO="sudo "
 fi
 
-push() { rsync "${RSYNC_OPTS[@]}" "$@"; }
+# Source folders and top-level files to deploy. Directories are copied
+# wholesale; __pycache__/*.pyc are filtered via RSYNC_OPTS.
+PATHS=(modalapistomp.py modalapi pistomp common fonts images ui uilib util)
+[ -d blend ] && PATHS+=(blend)
 
 echo "Deploying Python files to pistomp..."
 
-# Copy Python files to device
-push modalapistomp.py "${HOST}:${DEST}/"
-push modalapi/*.py "${HOST}:${DEST}/modalapi/"
+# wifi.py became the wifi/ package; rsync (no --delete) won't drop the stale file.
 ssh "${HOST}" "${SUDO}rm -f ${DEST}/modalapi/wifi.py"
-push modalapi/wifi/*.py "${HOST}:${DEST}/modalapi/wifi/"
-push pistomp/*.py "${HOST}:${DEST}/pistomp/"
-push pistomp/tuner/*.py "${HOST}:${DEST}/pistomp/tuner/"
-if [ -d blend ]; then
-    push blend "${HOST}:${DEST}/"
-fi
-push common "${HOST}:${DEST}/"
-push fonts "${HOST}:${DEST}/"
-push images "${HOST}:${DEST}/"
-push ui "${HOST}:${DEST}/"
-push uilib "${HOST}:${DEST}/"
-push util "${HOST}:${DEST}/"
+
+rsync "${RSYNC_OPTS[@]}" "${PATHS[@]}" "${HOST}:${DEST}/"
 
 echo "Restarting service..."
 ssh "${HOST}" "sudo systemctl restart mod-ala-pi-stomp"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,42 +1,60 @@
 #!/bin/bash
 set -e
 
+HOST="pistomp@pistomp.local"
+DEST="/home/pistomp/pi-stomp"
+
+# Two device layouts are supported:
+#   old world: ~/pi-stomp is a plain user-owned directory  -> plain rsync
+#   new world: ~/pi-stomp is a symlink to the root-owned, pacman-packaged
+#              /opt/pistomp/pi-stomp tree                  -> rsync via `sudo rsync`
+# Detect which one we're on and only elevate if the target is a symlink.
+RSYNC_OPTS=(-az)
+SUDO=""
+if ssh "${HOST}" "test -L ${DEST}"; then
+    echo "Detected packaged layout (~/pi-stomp is a symlink); writing with sudo on device."
+    RSYNC_OPTS+=(--rsync-path="sudo rsync")
+    SUDO="sudo "
+fi
+
+push() { rsync "${RSYNC_OPTS[@]}" "$@"; }
+
 echo "Deploying Python files to pistomp..."
 
 # Copy Python files to device
-scp modalapistomp.py pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp modalapi/*.py pistomp@pistomp.local:/home/pistomp/pi-stomp/modalapi/
-ssh pistomp@pistomp.local "rm -f /home/pistomp/pi-stomp/modalapi/wifi.py"
-scp modalapi/wifi/*.py pistomp@pistomp.local:/home/pistomp/pi-stomp/modalapi/wifi/
-scp pistomp/*.py pistomp@pistomp.local:/home/pistomp/pi-stomp/pistomp/
-scp pistomp/tuner/*.py pistomp@pistomp.local:/home/pistomp/pi-stomp/pistomp/tuner/
+push modalapistomp.py "${HOST}:${DEST}/"
+push modalapi/*.py "${HOST}:${DEST}/modalapi/"
+ssh "${HOST}" "${SUDO}rm -f ${DEST}/modalapi/wifi.py"
+push modalapi/wifi/*.py "${HOST}:${DEST}/modalapi/wifi/"
+push pistomp/*.py "${HOST}:${DEST}/pistomp/"
+push pistomp/tuner/*.py "${HOST}:${DEST}/pistomp/tuner/"
 if [ -d blend ]; then
-    scp -r blend pistomp@pistomp.local:/home/pistomp/pi-stomp/
+    push blend "${HOST}:${DEST}/"
 fi
-scp -r common pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp -r fonts pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp -r images pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp -r ui pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp -r uilib pistomp@pistomp.local:/home/pistomp/pi-stomp/
-scp -r util pistomp@pistomp.local:/home/pistomp/pi-stomp/
+push common "${HOST}:${DEST}/"
+push fonts "${HOST}:${DEST}/"
+push images "${HOST}:${DEST}/"
+push ui "${HOST}:${DEST}/"
+push uilib "${HOST}:${DEST}/"
+push util "${HOST}:${DEST}/"
 
 echo "Restarting service..."
-ssh pistomp@pistomp.local "sudo systemctl restart mod-ala-pi-stomp"
+ssh "${HOST}" "sudo systemctl restart mod-ala-pi-stomp"
 
 # Tail logs during startup (2 seconds) then check status
 echo "Service starting, showing logs..."
 echo "----------------------------------------"
-ssh pistomp@pistomp.local "timeout 2 sudo journalctl -u mod-ala-pi-stomp -f --since '1 second ago' 2>/dev/null || true"
+ssh "${HOST}" "timeout 2 sudo journalctl -u mod-ala-pi-stomp -f --since '1 second ago' 2>/dev/null || true"
 echo "----------------------------------------"
 
 # Check if service started successfully
-if ssh pistomp@pistomp.local "sudo systemctl is-active --quiet mod-ala-pi-stomp"; then
+if ssh "${HOST}" "sudo systemctl is-active --quiet mod-ala-pi-stomp"; then
     echo "Service started successfully."
 else
     echo "ERROR: Service failed to start!"
     echo "----------------------------------------"
     echo "Service status:"
-    ssh pistomp@pistomp.local "sudo systemctl status mod-ala-pi-stomp"
+    ssh "${HOST}" "sudo systemctl status mod-ala-pi-stomp"
     exit 1
 fi
 


### PR DESCRIPTION
Two changes here:

1. Instead of hardcoding paths, we simply now recurse to find all files in chosen directories (and exclude compiled/cache files).
2. The script now supports a root-owned symlink. This is because pistomp-arch is moving to using PKGBUILD to install all upgradeable packages; it's still an in-place upgrade, it just needs `sudo` (and will get obliterated if the package is upgraded).

