### PR TITLE
Fix a JACK deadlock

### DIFF
--- a/pistomp/tuner/source.py
+++ b/pistomp/tuner/source.py
@@ -53,6 +53,8 @@ class JackSource:
 
     def stop(self) -> None:
         if self._client is not None:
+            # Silence the process callback before teardown (prevents deadlock w/JACK)
+            self._on_samples = None
             try:
                 self._client.deactivate()
                 self._client.close()


### PR DESCRIPTION
Can happen when switching inputs; caused by a race between cFFT and JACK on the main thread