### PR TITLE
clear /run/lcd.init on each process start

### DIFF
--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -140,6 +140,8 @@ class Lcd(abstract_lcd.Lcd):
 
         self.wifi_menu = WifiMenu(self)
 
+        # Skip the in-app splash when early boot already showed one (/run/lcd.init).
+        # Hardware reset/clear still runs every process start (see LcdIli9341).
         if not display.has_system_splash:
             self.splash_show(True)
 

--- a/uilib/lcd_ili9341.py
+++ b/uilib/lcd_ili9341.py
@@ -21,6 +21,8 @@ import logging
 import threading
 import os
 
+# Written by early-boot splash integration before pi-stomp starts; lives in tmpfs
+# (/run) for the current boot only. pi-stomp reads it but never creates it.
 INIT_STAMP = "/run/lcd.init"
 
 
@@ -29,16 +31,17 @@ class LcdIli9341(LcdBase):
     # TODO: Turn "flip" into all 90deg angle combinations
     def __init__(self, spi, cs_pin, dc_pin, reset_pin, baudrate, flip=True):
         import adafruit_rgb_display.ili9341 as ili9341
-        rst = reset_pin if not self.has_system_splash else None
-        self.disp = ili9341.ILI9341(spi, cs=cs_pin, dc=dc_pin, rst=rst, baudrate=baudrate)
+        self.disp = ili9341.ILI9341(
+            spi, cs=cs_pin, dc=dc_pin, rst=reset_pin, baudrate=baudrate
+        )
 
         # Use this to assure we don't have multiple threads trying to change the screen
         # All methods which do change the screen (eg. dist. calls) should acquire/release
         self.lock = threading.Lock()
 
-        if not self.has_system_splash:
-            self.clear()
-            self._set_stamp()
+        # Always reset and clear on process start so service restarts are reliable.
+        # has_system_splash (INIT_STAMP) only skips the in-app splash in lcd320x240.
+        self.clear()
 
         # Test full screen image
         self.width = self.disp.height
@@ -47,15 +50,8 @@ class LcdIli9341(LcdBase):
 
     @cached_property
     def has_system_splash(self):
-        """Does the OS provide a splash screen?"""
+        """True when early boot left INIT_STAMP (OS splash already shown this boot)."""
         return os.path.exists(INIT_STAMP)
-
-    def _set_stamp(self):
-        try:
-            with open(INIT_STAMP, "w") as _f:
-                pass
-        except Exception:
-            pass
 
     def dimensions(self):
         return (self.width, self.height)

--- a/uilib/panel.py
+++ b/uilib/panel.py
@@ -176,6 +176,7 @@ class LcdBase(ABC):
 
     @property
     def has_system_splash(self) -> bool:
+        """False for backends without OS splash integration (emulator, tests)."""
         return False
 
 


### PR DESCRIPTION
always reset and clear /run/lcd.init file on process start so service restarts are reliable.