### PR TITLE
Don't show tuner for v2 hardware

### DIFF
--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -107,7 +107,8 @@ class Modhandler(Handler):
         self.ws_bridge.start()
         logging.info("WebSocket bridge started")
 
-        # Tuner state
+        # Tuner state (may be disabled on slow hardware)
+        self.tuner_supported: bool = True
         self._tuner_engine: TunerEngine | None = None
         self._tuner_panel: TunerPanel | None = None
         self._tuner_source_factory: TunerSourceFactory | None = None
@@ -1049,6 +1050,8 @@ class Modhandler(Handler):
         return factory(port, name=f"pistomp-tuner-{port.split('_')[-1]}")
 
     def toggle_tuner_enable(self, *argv) -> None:
+        if not self.tuner_supported:
+            return
         if self._tuner_engine is None:
             muted = bool(self.settings.get_setting(Token.TUNER_MUTE))
             input_port = int(self.settings.get_setting(Token.TUNER_INPUT) or 1)

--- a/pistomp/handlerfactory.py
+++ b/pistomp/handlerfactory.py
@@ -38,6 +38,7 @@ class Handlerfactory:
             handler = Mod.Mod(audiocard, cwd)
         elif (version >= 2.0) and (version < 3.0):
             handler = Modhandler.Modhandler(audiocard, cwd)
+            handler.tuner_supported = False
         elif (version >= 3.0) and (version < 4.0):
             handler = Modhandler.Modhandler(audiocard, cwd)
         else:

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -545,9 +545,10 @@ class Lcd(abstract_lcd.Lcd):
     # System Menu
     #
     def draw_system_menu(self, event, widget):
-        items = [("System info", self.draw_system_info_dialog, None),
-                 ("Tuner", self._toggle_tuner_from_menu, None),
-                 ("System shutdown", self.handler.system_menu_shutdown, None),
+        items = [("System info", self.draw_system_info_dialog, None)]
+        if self.handler and self.handler.tuner_supported:
+            items.append(("Tuner", self._toggle_tuner_from_menu, None))
+        items += [("System shutdown", self.handler.system_menu_shutdown, None),
                  ("System reboot",  self.handler.system_menu_reboot, None),
                  ("Restart sound engine", self.handler.system_menu_restart_sound, None),
                  ("Bank Select >", self.draw_bank_menu, None),


### PR DESCRIPTION
The current tuner is not working on v2. Remove it from its system menu to not block the release. Confirmed the "Tuner" boots up and works on v3 still.