### PR TITLE
Use dpkg-query for pkg version

### DIFF
--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -950,7 +950,12 @@ class Mod(Handler):
                 self.git_describe = output.decode()
                 self.software_version = self.git_describe.split('-')[0]
         except subprocess.CalledProcessError:
-            logging.error("Cannot obtain git software tag info")
+            try:
+                output = subprocess.check_output(['dpkg-query', '--showformat=${Version}', '--show', 'pi-stomp'])
+                self.git_describe = output.decode().strip()
+                self.software_version = self.git_describe
+            except subprocess.CalledProcessError:
+                logging.error("Cannot obtain software version info")
 
         self.eq_status = self.audiocard.get_switch_parameter(self.audiocard.DAC_EQ)
         self.lcd.update_eq(self.eq_status)

--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -800,7 +800,12 @@ class Modhandler(Handler):
                 self.software_version = output.decode()
                 logging.info("pi-Stomp Software Version: %s" % self.software_version)
         except subprocess.CalledProcessError:
-            logging.error("Cannot obtain git software tag info")
+            try:
+                output = subprocess.check_output(['dpkg-query', '--showformat=${Version}', '--show', 'pi-stomp'])
+                self.software_version = output.decode().strip()
+                logging.info("pi-Stomp Software Version (pkg): %s" % self.software_version)
+            except subprocess.CalledProcessError:
+                logging.error("Cannot obtain software version info")
 
         try:
             if Path(self.build_file).exists():


### PR DESCRIPTION
If there's no `.git` folder (happens when we install via dpkg and strip it), fall back to grabbing the pi-stomp software version from the deb that's installed.