### PR TITLE
Reorder init values before callbacks in case there is a pending one

### DIFF
--- a/pistomp/encoder.py
+++ b/pistomp/encoder.py
@@ -37,6 +37,13 @@ class Encoder:
         self._lock = threading.Lock()
         self.data: Any = None
         self.clk: Any = None
+
+        self.prevNextCode = 0
+        self.store = 0
+        self.direction = 0
+        # 16 grey codes; 1 = valid transition, 0 = bounce.
+        self.rot_enc_table = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
+
         if d_pin is not None:
             from gpiozero import Button  # pyright: ignore[reportMissingImports]
 
@@ -46,12 +53,6 @@ class Encoder:
             self.clk = Button(clk_pin)
             self.clk.when_pressed = self._gpio_callback
             self.clk.when_released = self._gpio_callback
-
-        self.prevNextCode = 0
-        self.store = 0
-        self.direction = 0
-        # 16 grey codes; 1 = valid transition, 0 = bounce.
-        self.rot_enc_table = [0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
 
     def __del__(self):
         if self.data is not None:


### PR DESCRIPTION
Prevent a crash going from pistomp-recovery back to pi-stomp when there is a latent GPIO callback. After hooking up the v2 potentiometers in pistomp-recovery, the risk of triggering this callback increased. This ordering prevents a crash (`self.prevNextCode is not an attribute`)