### PR TITLE
Make stamping a background process

### DIFF
--- a/modalapi/mod.py
+++ b/modalapi/mod.py
@@ -828,7 +828,7 @@ class Mod(Handler):
         # Stamp as known-good — only stamp when mod-host confirmed success
         if ok:
             try:
-                subprocess.run(["pistomp-stamp", "stamp", pedalboard.bundle], check=False)
+                subprocess.Popen(["pistomp-stamp", "stamp", pedalboard.bundle])
             except Exception:
                 logging.debug("pistomp-stamp failed", exc_info=True)
 

--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -681,7 +681,7 @@ class Modhandler(Handler):
 
                 # Stamp as known-good — only pi-stomp knows the full stack is healthy
                 try:
-                    subprocess.run(["pistomp-stamp", "stamp", mod_bundle], check=False)
+                    subprocess.Popen(["pistomp-stamp", "stamp", mod_bundle])
                 except Exception:
                     logging.debug("pistomp-stamp failed", exc_info=True)
             elif mod_bundle and self._current is not None and self.next_pedalboard_preset_index is not None:

--- a/tests/v1/test_stamp.py
+++ b/tests/v1/test_stamp.py
@@ -24,7 +24,7 @@ def _stamp_calls(mock_run):
 def _assert_stamp_called(mock_run, times: int = 1):
     calls = _stamp_calls(mock_run)
     assert len(calls) == times, (
-        f"Expected {times} pistomp-stamp call(s), got {len(calls)}. All subprocess.run calls: {mock_run.call_args_list}"
+        f"Expected {times} pistomp-stamp call(s), got {len(calls)}. All subprocess.Popen calls: {mock_run.call_args_list}"
     )
 
 
@@ -44,7 +44,7 @@ class TestStampOnPedalboardChange:
 
     def test_stamp_called_on_pedalboard_change(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.pedalboard_change(handler.pedalboard_list[0])
         _assert_stamp_called(mock_run, times=1)
 
@@ -52,7 +52,7 @@ class TestStampOnPedalboardChange:
         handler = v1_system.handler
         handler.selected_pedalboard_index = 1
         handler.top_encoder_mode = type(handler.top_encoder_mode).PEDALBOARD_SELECTED
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.top_encoder_sw(switchstate.Value.RELEASED)
         _assert_stamp_called(mock_run, times=1)
 
@@ -61,7 +61,7 @@ class TestStampOnPedalboardChange:
         means 'I know this works' and a failed load is not known-good."""
         handler = v1_system.handler
         with (
-            patch("modalapi.mod.subprocess.run") as mock_run,
+            patch("modalapi.mod.subprocess.Popen") as mock_run,
             patch("modalapi.mod.req.get") as mock_get,
             patch("modalapi.mod.req.post") as mock_post,
         ):
@@ -79,7 +79,7 @@ class TestStampOnPedalboardChange:
 
     def test_stamp_exception_is_caught(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run", side_effect=FileNotFoundError("no binary")):
+        with patch("modalapi.mod.subprocess.Popen", side_effect=FileNotFoundError("no binary")):
             handler.pedalboard_change(handler.pedalboard_list[0])
 
 
@@ -90,13 +90,13 @@ class TestNoStampOnSetCurrentPedalboard:
     def test_no_stamp_on_direct_set(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
         pb = handler.pedalboards["/path/to/rig.pedalboard"]
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.set_current_pedalboard(pb)
         _assert_stamp_not_called(mock_run)
 
     def test_no_stamp_on_load_pedalboards(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.load_pedalboards()
         _assert_stamp_not_called(mock_run)
 
@@ -106,18 +106,18 @@ class TestStampNotCalledOnNonChangeOperations:
 
     def test_no_stamp_on_preset_change(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.preset_change()
         _assert_stamp_not_called(mock_run)
 
     def test_no_stamp_on_bypass_toggle(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.toggle_plugin_bypass()
         _assert_stamp_not_called(mock_run)
 
     def test_no_stamp_on_parameter_value_change(self, v1_system: SystemFixtureLegacy):
         handler = v1_system.handler
-        with patch("modalapi.mod.subprocess.run") as mock_run:
+        with patch("modalapi.mod.subprocess.Popen") as mock_run:
             handler.parameter_value_change(0, lambda: None)
         _assert_stamp_not_called(mock_run)

--- a/tests/v3/test_stamp.py
+++ b/tests/v3/test_stamp.py
@@ -20,7 +20,7 @@ def _assert_stamp_called(mock_run, times: int = 1):
     calls = _stamp_calls(mock_run)
     assert len(calls) == times, (
         f"Expected {times} pistomp-stamp call(s), got {len(calls)}. "
-        f"All subprocess.run calls: {mock_run.call_args_list}"
+        f"All subprocess.Popen calls: {mock_run.call_args_list}"
     )
 
 
@@ -58,7 +58,7 @@ class TestStampOnPedalboardChange:
         last_json.write_text(json.dumps({"pedalboard": "/path/to/new.pedalboard"}))
         os.utime(last_json, (9999, 9999))
 
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.poll_modui_changes()
 
         _assert_stamp_called(mock_run, times=1)
@@ -67,7 +67,7 @@ class TestStampOnPedalboardChange:
         """poll_modui_changes() must NOT stamp when last.json hasn't changed."""
         handler = v3_system.handler
 
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.poll_modui_changes()
 
         _assert_stamp_not_called(mock_run)
@@ -81,7 +81,7 @@ class TestStampOnPedalboardChange:
         last_json.write_text(json.dumps({"pedalboard": "/path/to/rig.pedalboard"}))
         os.utime(last_json, (9999, 9999))
 
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.poll_modui_changes()
 
         _assert_stamp_not_called(mock_run)
@@ -94,13 +94,13 @@ class TestNoStampOnSetCurrentPedalboard:
     def test_no_stamp_on_direct_set(self, v3_system: SystemFixture):
         handler = v3_system.handler
         pb = handler.pedalboards["/path/to/rig.pedalboard"]
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.set_current_pedalboard(pb)
         _assert_stamp_not_called(mock_run)
 
     def test_no_stamp_on_load_pedalboards(self, v3_system: SystemFixture):
         handler = v3_system.handler
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.load_pedalboards()
         _assert_stamp_not_called(mock_run)
 
@@ -110,12 +110,15 @@ class TestStampNotCalledOnNonChangeOperations:
 
     def test_no_stamp_on_preset_change(self, v3_system: SystemFixture):
         handler = v3_system.handler
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with patch("modalapi.modhandler.subprocess.Popen") as mock_run:
             handler.preset_change(0)
         _assert_stamp_not_called(mock_run)
 
     def test_no_stamp_on_system_info_load(self, v3_system: SystemFixture):
         handler = v3_system.handler
-        with patch("modalapi.modhandler.subprocess.run") as mock_run:
+        with (
+            patch("modalapi.modhandler.subprocess.run") as mock_run,
+            patch("modalapi.modhandler.subprocess.Popen") as mock_popen,
+        ):
             handler.system_info_load()
-        _assert_stamp_not_called(mock_run)
+        _assert_stamp_not_called(mock_popen)

--- a/tests/v3/test_stamp.py
+++ b/tests/v3/test_stamp.py
@@ -117,7 +117,7 @@ class TestStampNotCalledOnNonChangeOperations:
     def test_no_stamp_on_system_info_load(self, v3_system: SystemFixture):
         handler = v3_system.handler
         with (
-            patch("modalapi.modhandler.subprocess.run") as mock_run,
+            patch("modalapi.modhandler.subprocess.run"),
             patch("modalapi.modhandler.subprocess.Popen") as mock_popen,
         ):
             handler.system_info_load()


### PR DESCRIPTION
This prevents `pistomp-stamp` from freezing the UI for ~2.5s every time a pedalboard is changed. Because I forgot to put it in PATH, no stamping is actually happening right now. This fixes that.