### PR TITLE
feat: add clear_binding_range support and update unmap logic to resto…

### DIFF
--- a/common/parameter.py
+++ b/common/parameter.py
@@ -134,16 +134,16 @@ class Parameter:
         self.hidden: bool = is_hidden_port(plugin_info)
 
         ranges = plugin_info.get("ranges") or Ranges()
-        declared_minimum = float(ranges.get("minimum", 0.0))
-        declared_maximum = float(ranges.get("maximum", 1.0))
+        self.declared_minimum: float = float(ranges.get("minimum", 0.0))
+        self.declared_maximum: float = float(ranges.get("maximum", 1.0))
         # minimum/maximum are the *effective* extents: the plugin's declared LV2
         # range, unless a MIDI-CC binding carries a custom sub-range
         self.minimum: float
         self.maximum: float
-        self.minimum, self.maximum = binding_range or (declared_minimum, declared_maximum)
+        self.minimum, self.maximum = binding_range or (self.declared_minimum, self.declared_maximum)
         # mod-ui normalises the TTL and always emits all three ranges; the
         # fallbacks only serve the params we synthesise (bypass, volume, VU).
-        self.default: float = float(ranges.get("default", declared_minimum))
+        self.default: float = float(ranges.get("default", self.declared_minimum))
 
         # Reactive value. Writes go through reconcile/preview/commit, never a raw
         # setter — the verb names the provenance (see those methods). _confirmed
@@ -226,8 +226,21 @@ class Parameter:
             observe(self)
 
     def set_binding_range(self, binding_range: tuple[float, float]) -> None:
-        """Set the effective extents from a MIDI-CC (sub-)range."""
-        self.minimum, self.maximum = binding_range
+        """Set the effective extents from a MIDI-CC (sub-)range and notify observers."""
+        if (self.minimum, self.maximum) != binding_range:
+            self.minimum, self.maximum = binding_range
+            self._value = max(self.minimum, min(self._value, self.maximum))
+            for observe in self._observers:
+                observe(self)
+
+    def clear_binding_range(self) -> None:
+        """Restore effective extents to the plugin's declared LV2 range and notify observers."""
+        if (self.minimum, self.maximum) != (self.declared_minimum, self.declared_maximum):
+            self.minimum = self.declared_minimum
+            self.maximum = self.declared_maximum
+            self._value = max(self.minimum, min(self._value, self.maximum))
+            for observe in self._observers:
+                observe(self)
 
     def subscribe(self, cb: Callable[[Parameter], None]) -> Callable[[], None]:
         """Register *cb* to fire on every changed-value write. Returns its own

--- a/pistomp/handler.py
+++ b/pistomp/handler.py
@@ -224,9 +224,12 @@ class Handler(InputSink):
         controller = self.hardware.controllers.get(binding)
         # The range can change without the binding (re-address the same CC to a
         # different sub-range), so apply it before the binding-unchanged bail.
-        # Never on unmap: -1:-1 names no controller and must not reset the range.
-        if binding_range is not None and controller is not None:
+        # On unmap (binding "-1:-1" or "-1"), restore the plugin's declared LV2 range.
+        is_unmapped = binding in ("-1:-1", "-1")
+        if binding_range is not None and not is_unmapped:
             param.set_binding_range(binding_range)
+        elif is_unmapped:
+            param.clear_binding_range()
         if param.binding == binding:
             return
 

--- a/tests/test_parameter_binding_range.py
+++ b/tests/test_parameter_binding_range.py
@@ -61,6 +61,52 @@ def test_set_binding_range_preserves_identity():
     assert id(p) == before
 
 
+def test_clear_binding_range_restores_declared_range():
+    """Calling clear_binding_range resets minimum and maximum to declared_minimum and declared_maximum."""
+    p = Parameter(_port(30.0, 800.0), 100.0, binding="0:70", binding_range=(100.0, 400.0))
+    assert (p.minimum, p.maximum) == (100.0, 400.0)
+    p.clear_binding_range()
+    assert (p.minimum, p.maximum) == (30.0, 800.0)
+
+
+def test_binding_range_notifies_subscribers_and_clamps_value():
+    """set_binding_range and clear_binding_range notify observers and clamp value if out of bounds."""
+    p = Parameter(_port(0.0, 1.0), 0.9, binding="0:70", binding_range=(0.0, 1.0))
+    notifications = []
+    p.subscribe(lambda param: notifications.append(param.value))
+
+    # Narrow range past current value (0.9 -> 0.5 max)
+    p.set_binding_range((0.0, 0.5))
+    assert p.value == 0.5
+    assert len(notifications) == 1
+
+    # Clear binding range back to 0.0 .. 1.0
+    p.clear_binding_range()
+    assert (p.minimum, p.maximum) == (0.0, 1.0)
+    assert p.value == 0.5  # Remains at 0.5 when restored
+    assert len(notifications) == 2
+
+
+def test_set_binding_range_is_idempotent():
+    """A connect-dump replay re-sends the same range; equality guard suppresses it."""
+    p = Parameter(_port(0.0, 1.0), 0.5, binding="0:70", binding_range=(0.0, 0.5))
+    notifications = []
+    p.subscribe(lambda param: notifications.append(param.value))
+    p.set_binding_range((0.0, 0.5))
+    assert len(notifications) == 0
+
+
+def test_clear_binding_range_is_idempotent():
+    """A replayed unmap (-1:-1) after the range is already restored is a no-op."""
+    p = Parameter(_port(30.0, 800.0), 400.0, binding="0:70", binding_range=(100.0, 400.0))
+    notifications = []
+    p.subscribe(lambda param: notifications.append(param.value))
+    p.clear_binding_range()
+    assert len(notifications) == 1
+    p.clear_binding_range()
+    assert len(notifications) == 1
+
+
 def test_step_grid_sweeps_only_the_sub_range():
     """The encoder grid's endpoints follow the sub-range, so a full spin can no
     longer reach the plugin's declared maximum."""

--- a/tests/v3/test_midi_learn.py
+++ b/tests/v3/test_midi_learn.py
@@ -481,9 +481,9 @@ def test_v3_midi_learn_updated_binding_range_on_same_parameter(v3_system: System
     assert plugin.controllers.count(enc1) == 1
 
 
-def test_v3_midi_unlearn_preserves_sub_range(v3_system: SystemFixture, make_plugin, make_parameter):
-    """Unmapping (-1:-1) must not reset the parameter's bound sub-range to the
-    full 0..1 default that the unmap frame carries."""
+def test_v3_midi_unlearn_restores_declared_range(v3_system: SystemFixture, make_plugin, make_parameter):
+    """Unmapping (-1:-1) restores the parameter's declared LV2 range rather than
+    keeping the narrowed sub-range or applying the 0..1 unmap frame default."""
     handler = v3_system.handler
     hw = v3_system.hw
     ws_bridge = v3_system.ws_bridge
@@ -504,7 +504,39 @@ def test_v3_midi_unlearn_preserves_sub_range(v3_system: SystemFixture, make_plug
     ws_bridge.inject("midi_map /graph/noise gain -1 -1 0.0 1.0")
     handler.poll_ws_messages()
     assert gain.binding is None
-    assert (gain.minimum, gain.maximum) == (0.1, 0.9)
+    assert (gain.minimum, gain.maximum) == (gain.declared_minimum, gain.declared_maximum)
+
+
+def test_v3_midi_learn_free_cc_preserves_sub_range(v3_system: SystemFixture, make_plugin, make_parameter):
+    """A midi_map naming a CC with no physical pi-stomp control (an external/free
+    MIDI CC) must still apply its sub-range — the guard keys off the -1:-1 unmap
+    sentinel, not controller presence, so a real external device's extents are shown."""
+    handler = v3_system.handler
+    hw = v3_system.hw
+    ws_bridge = v3_system.ws_bridge
+
+    assert handler.current
+
+    used = set(hw.controllers)
+    binding = next(
+        "%d:%d" % (ch, cc)
+        for ch in range(1, 16)
+        for cc in range(0, 127)
+        if "%d:%d" % (ch, cc) not in used
+    )
+    channel, cc = binding.split(":")
+
+    gain = make_parameter("Gain", "noise", value=0.5)
+    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    handler.current.pedalboard.plugins = [plugin]
+
+    ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.0 0.5")
+    handler.poll_ws_messages()
+
+    # No physical control to wire, so the binding is not adopted...
+    assert gain.binding is None
+    # ...but the external sub-range is preserved, not clobbered by 0..1 or dropped.
+    assert (gain.minimum, gain.maximum) == (0.0, 0.5)
 
 
 def test_v3_midi_learn_moving_footswitch_binding_clears_old_lcd_display(v3_system: SystemFixture, make_plugin):


### PR DESCRIPTION
should fix #226 


### Problem

When a parameter is MIDI-learned to a narrowed sub-range (e.g. a `0.0–1.0` port addressed as `0.1–0.2`), removing the mapping in MOD-UI never restores the plugin's declared LV2 range. The parameter stays clamped to the dead sub-range until a pedalboard reload, so the LCD dialog paints the wrong endpoints and the value can't reach the plugin's declared extents.

### Root cause

`Parameter.__init__` folded the plugin's declared LV2 range into `self.minimum` / `self.maximum` as **local variables** and discarded them. Once `set_binding_range()` narrowed the effective extents, the original declared pair was unrecoverable — unmap had nothing to restore to.

PR #218 guarded against the unmap frame's default `0.0–1.0` overwriting non-normalised ports (correct), but it left the parameter permanently stuck at the sub-range.

### Fix

1. **`common/parameter.py`** — keep the declared LV2 range as fields (`declared_minimum` / `declared_maximum`) instead of tossing them; add `clear_binding_range()` to restore them. Both it and `set_binding_range()` now clamp `_value`, guard against idempotent replays, and notify observers so active dialogs repaint immediately.
2. **`pistomp/handler.py`** — unmap is now detected by the MOD-UI `-1:-1` sentinel rather than `controller is None`. That disambiguates a real unmap (restore declared range) from an external/free MIDI CC (preserve its genuine sub-range), which the old guard had wrongly conflated.

### Tests

- `test_v3_midi_unlearn_restores_declared_range` — unmap restores the declared LV2 range.
- `test_v3_midi_learn_free_cc_preserves_sub_range` — a free/external CC keeps its real sub-range (locks the sentinel behavior).
- `test_clear_binding_range_restores_declared_range` + `test_binding_range_notifies_subscribers_and_clamps_value` — unit coverage.
- `test_set_binding_range_is_idempotent` / `test_clear_binding_range_is_idempotent` — replays produce zero notifications.
