### PR TITLE
Add infrastucture for creating a screen capture of the current LCD

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -132,3 +132,19 @@ def test_my_flow(v3_system, snapshot):
 ```
 
 On a snapshot mismatch: **fix real failures first.** When only snapshot differences remain, run `--snapshot-update` to populate the working copy, then show me the changed files as soon as they regenerate and what you expect them to look like. You can lean on me to tell you if anything's wrong.
+
+## Create an LCD screen capture
+
+It's often useful to create screen capture of the current LCD for documentation, debugging, etc.
+
+On the pi-Stomp with all services running, execute the following:
+
+```bash
+uv run python ~/pi-stomp/util/record_lcd.py --still
+```
+That writes a date-stamped file named: ~/pistomp_capture_YYYYMMDD_HHMMSS.png
+
+To alternatively specify the filename:
+```bash
+uv run python ~/pi-stomp/util/record_lcd.py --still -o FILE-PATH
+```

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -135,7 +135,7 @@ On a snapshot mismatch: **fix real failures first.** When only snapshot differen
 
 ## Create an LCD screen capture
 
-It's often useful to create screen capture of the current LCD for documentation, debugging, etc.
+It's often useful to a create screen capture of the current LCD for documentation, debugging, etc.
 
 On the pi-Stomp with all services running, execute the following:
 

--- a/tests/test_record_lcd.py
+++ b/tests/test_record_lcd.py
@@ -1,0 +1,97 @@
+"""LCD still-capture: BGRA → PNG, and the unix-socket handshake."""
+
+import importlib.util
+import os
+import socket
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+_SPEC = importlib.util.spec_from_file_location(
+    "record_lcd", Path(__file__).resolve().parent.parent / "util" / "record_lcd.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+record_lcd = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(record_lcd)
+
+W, H = record_lcd.WIDTH, record_lcd.HEIGHT
+RED_BGRA = bytes((0, 0, 255, 255)) * (W * H)
+
+
+def _short_sock() -> str:
+    # AF_UNIX sun_path is 104 bytes on macOS; pytest tmp_path overruns it.
+    return f"/tmp/pistomp-lcd-test-{uuid.uuid4().hex}.sock"
+
+
+def test_write_png_decodes_bgra_red(tmp_path):
+    path = tmp_path / "red.png"
+    record_lcd.write_png(RED_BGRA, str(path))
+    img = Image.open(path)
+    assert img.size == (W, H)
+    assert img.getpixel((0, 0)) == (255, 0, 0)
+    assert img.getpixel((W - 1, H - 1)) == (255, 0, 0)
+
+
+def test_write_png_rejects_short_buffer(tmp_path):
+    with pytest.raises(ValueError, match="expected"):
+        record_lcd.write_png(b"\x00\x01\x02", str(tmp_path / "x.png"))
+
+
+def _connect_when_ready(path: str, timeout: float = 2.0) -> socket.socket:
+    deadline = time.time() + timeout
+    last_err: OSError | None = None
+    while time.time() < deadline:
+        if os.path.exists(path):
+            try:
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.connect(path)
+                return sock
+            except OSError as e:
+                last_err = e
+        time.sleep(0.01)
+    raise TimeoutError(last_err)
+
+
+def test_capture_still_writes_one_frame(tmp_path):
+    sock_path = _short_sock()
+    out = str(tmp_path / "lcd.png")
+    errors: list[BaseException] = []
+
+    def _run():
+        try:
+            record_lcd.capture_still(out, socket_path=sock_path, timeout=5.0)
+        except BaseException as e:
+            errors.append(e)
+
+    t = threading.Thread(target=_run)
+    t.start()
+    try:
+        client = _connect_when_ready(sock_path)
+        try:
+            client.sendall(RED_BGRA)
+        finally:
+            client.close()
+        t.join(timeout=5)
+        assert not t.is_alive()
+        assert errors == []
+        img = Image.open(out)
+        assert img.getpixel((10, 10)) == (255, 0, 0)
+    finally:
+        t.join(timeout=1)
+        if os.path.exists(sock_path):
+            os.remove(sock_path)
+
+
+def test_capture_still_times_out(tmp_path):
+    sock_path = _short_sock()
+    try:
+        with pytest.raises(TimeoutError, match="Timed out"):
+            record_lcd.capture_still(str(tmp_path / "lcd.png"), socket_path=sock_path, timeout=0.15)
+        assert not os.path.exists(sock_path)
+    finally:
+        if os.path.exists(sock_path):
+            os.remove(sock_path)

--- a/util/record_lcd.py
+++ b/util/record_lcd.py
@@ -19,12 +19,15 @@
 
 import os
 import socket
+import sys
 import time
 import subprocess
 import datetime
 import threading
 import signal
 import argparse
+import struct
+import zlib
 
 SOCKET_PATH = "/tmp/pistomp-lcd.sock"
 WIDTH = 320
@@ -32,6 +35,81 @@ HEIGHT = 240
 BPP = 4
 FRAME_SIZE = WIDTH * HEIGHT * BPP
 FPS = 60
+STILL_TIMEOUT_S = 30.0
+
+
+def bind_capture_socket(socket_path: str = SOCKET_PATH) -> socket.socket:
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_sock.bind(socket_path)
+    os.chmod(socket_path, 0o666)
+    return server_sock
+
+
+def unlink_socket(socket_path: str) -> None:
+    if os.path.exists(socket_path):
+        os.remove(socket_path)
+
+
+def recv_frame(conn: socket.socket) -> bytes:
+    data = b""
+    while len(data) < FRAME_SIZE:
+        chunk = conn.recv(FRAME_SIZE - len(data))
+        if not chunk:
+            raise RuntimeError(f"connection closed after {len(data)}/{FRAME_SIZE} bytes")
+        data += chunk
+    return data
+
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+
+
+def _png_chunk(tag: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+
+def write_png(bgra: bytes, path: str) -> None:
+    if len(bgra) != FRAME_SIZE:
+        raise ValueError(f"expected {FRAME_SIZE} bytes, got {len(bgra)}")
+    mv = memoryview(bgra)
+    rgb = bytearray(WIDTH * HEIGHT * 3)
+    rgb[0::3] = mv[2::4]
+    rgb[1::3] = mv[1::4]
+    rgb[2::3] = mv[0::4]
+    stride = WIDTH * 3
+    raw = b"".join(b"\x00" + rgb[y * stride : (y + 1) * stride] for y in range(HEIGHT))
+    with open(path, "wb") as f:
+        f.write(_PNG_SIG)
+        f.write(_png_chunk(b"IHDR", struct.pack(">IIBBBBB", WIDTH, HEIGHT, 8, 2, 0, 0, 0)))
+        f.write(_png_chunk(b"IDAT", zlib.compress(raw, 9)))
+        f.write(_png_chunk(b"IEND", b""))
+
+
+def capture_still(output_path: str, *, socket_path: str = SOCKET_PATH, timeout: float = STILL_TIMEOUT_S) -> None:
+    """Listen for one LCD frame and write it as a PNG.
+
+    pi-stomp (device or emulator) connects to ``socket_path`` within a couple of
+    seconds of the socket appearing, then sends a full-screen BGRA frame.
+    """
+    server_sock = bind_capture_socket(socket_path)
+    server_sock.listen(1)
+    server_sock.settimeout(timeout)
+    print(f"Waiting for pi-stomp to connect to {socket_path}...")
+    try:
+        conn, _ = server_sock.accept()
+        with conn:
+            conn.settimeout(timeout)
+            conn.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, 4 * 1024 * 1024)
+            print("Connected to pi-stomp")
+            frame = recv_frame(conn)
+        write_png(frame, output_path)
+        print(f"Wrote {output_path}")
+    except TimeoutError as e:
+        raise TimeoutError(f"Timed out waiting for pi-stomp at {socket_path}") from e
+    finally:
+        server_sock.close()
+        unlink_socket(socket_path)
 
 
 class LcdRecorder:
@@ -99,12 +177,7 @@ class LcdRecorder:
             self.running = False
 
     def run(self):
-        if os.path.exists(SOCKET_PATH):
-            os.remove(SOCKET_PATH)
-
-        server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        server_sock.bind(SOCKET_PATH)
-        os.chmod(SOCKET_PATH, 0o666)  # Ensure pi-stomp can connect
+        server_sock = bind_capture_socket(SOCKET_PATH)
 
         # Handle signals
         signal.signal(signal.SIGINT, self.stop)
@@ -119,7 +192,8 @@ class LcdRecorder:
             process = subprocess.Popen(self.ffmpeg_cmd, stdin=subprocess.PIPE, stderr=subprocess.DEVNULL)
         except FileNotFoundError:
             print("Error: ffmpeg not found. Please install ffmpeg.")
-            os.remove(SOCKET_PATH)
+            server_sock.close()
+            unlink_socket(SOCKET_PATH)
             return
 
         print(f"Recording to {self.output_path}")
@@ -162,23 +236,38 @@ class LcdRecorder:
                 process.stdin.close()
             process.wait()
             server_sock.close()
-            if os.path.exists(SOCKET_PATH):
-                os.remove(SOCKET_PATH)
+            unlink_socket(SOCKET_PATH)
             print(f"Recording saved to {self.output_path}")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Record pi-stomp LCD to a video file.")
+    parser = argparse.ArgumentParser(description="Capture the live pi-stomp LCD (video, or a still PNG).")
     parser.add_argument("-o", "--output", help="Output file path")
     parser.add_argument("-l", "--lossless", action="store_true", help="Record in lossless mode (higher disk usage)")
+    parser.add_argument("-s", "--still", action="store_true", help="Capture a single PNG and exit")
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=STILL_TIMEOUT_S,
+        help=f"Seconds to wait for pi-stomp in --still mode (default {STILL_TIMEOUT_S:g})",
+    )
     args = parser.parse_args()
 
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    home = os.path.expanduser("~")
     if args.output:
         output_file = args.output
     else:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        home = os.path.expanduser("~")
-        output_file = os.path.join(home, f"pistomp_capture_{timestamp}.mp4")
+        ext = "png" if args.still else "mp4"
+        output_file = os.path.join(home, f"pistomp_capture_{timestamp}.{ext}")
 
-    recorder = LcdRecorder(output_file, lossless=args.lossless)
-    recorder.run()
+    if args.still:
+        try:
+            capture_still(output_file, timeout=args.timeout)
+        except TimeoutError as e:
+            print(e, file=sys.stderr)
+            sys.exit(1)
+    else:
+        recorder = LcdRecorder(output_file, lossless=args.lossless)
+        recorder.run()


### PR DESCRIPTION
It's often useful to a create screen capture of the current LCD for documentation, debugging, etc.

To use:
uv run python ~/pi-stomp/util/record_lcd.py --still

That writes a date-stamped file named: ~/pistomp_capture_YYYYMMDD_HHMMSS.png

To alternatively specify the filename:
uv run python ~/pi-stomp/util/record_lcd.py --still -o FILE-PATH