### PR TITLE
Scroll pedalboard/snapshot titles only when selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable user visible changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Pedalboard/snapshot titles now auto-scroll only while selected with the NAV encoder (at most one thing scrolls at a time, and they sit at their leftmost position otherwise) — LCD updates over SPI are audible on the DAC at high gain, so the screen stays quiet while you play
+### Fixed
+- Long titles scrolled slightly past their last pixel before bouncing back; the scroll window now matches the drawn text area exactly
+
 ## [v3.3.1] - 2026-08-14
 ### Fixed
 - Pedalboards list no longer shows deleted pedalboards after they are removed from MOD-UI

--- a/docs/lcd_worker_thread.md
+++ b/docs/lcd_worker_thread.md
@@ -5,6 +5,8 @@
 A full-frame push blocks the UI thread for **21.4 ms on v2** and **25.2 ms on v3**,
 against a 10 ms tick. Nothing mitigates this today.
 
+LCD SPI transfers can be audible through the DAC at high gain, so avoid LCD updates that are not associated with the user's input.
+
 `PanelStack.propagate_dirty` gates pushes on `transfer_ms(clip) <= INLINE_BUDGET_MS`
 (8 ms), which *looks* like it protects the poll loop. It doesn't. The deferred path
 — `poll_lcd_updates()` → `flush()` → `lcd.update()` — runs on the **same UI thread**

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -481,7 +481,6 @@ class Lcd:
                 font=self.title_font,
                 parent=self.main_panel,
                 action=self.draw_pedalboard_menu,
-                lcd_poll_divisor=self.poll_divisor,
                 subtitle="Pedalboard",
             )
             self.main_panel.add_sel_widget(self.w_pedalboard)
@@ -514,7 +513,6 @@ class Lcd:
             font=self.title_font,
             parent=self.main_panel,
             action=self.draw_preset_menu,
-            lcd_poll_divisor=self.poll_divisor,
             subtitle="Snapshot",
         )
         self.main_panel.add_sel_widget(self.w_preset)

--- a/pistomp/lcd320x240.py
+++ b/pistomp/lcd320x240.py
@@ -282,10 +282,11 @@ class Lcd:
     def _poll_updates(self):
         for d in self.w_parameter_dialogs.values():
             d.tick()
-        if self.w_pedalboard is not None:
-            self.w_pedalboard.tick()
-        if self.w_preset is not None:
-            self.w_preset.tick()
+        if self.pstack.current is self.main_panel:
+            if self.w_pedalboard is not None:
+                self.w_pedalboard.tick()
+            if self.w_preset is not None:
+                self.w_preset.tick()
         for wfs in self.w_footswitches:
             wfs.tick()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ Injected into sys.modules at import time so application code can be imported in 
 
 import os
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -231,6 +232,38 @@ class FakeLcd(LcdBase):
 @pytest.fixture
 def fake_lcd():
     return FakeLcd()
+
+
+# ---------------------------------------------------------------------------
+# FakeClock — deterministic wall time for tick-driven animations
+# ---------------------------------------------------------------------------
+
+
+class FakeClock:
+    """Deterministic time.monotonic for tick-driven animations.
+
+    Patches every module that reads the wall clock for animation pacing
+    (they all share the stdlib time module, so one attribute carries all
+    of them). ``drive(widget, dt, n)`` simulates n mainloop passes:
+    advance the clock by dt, then tick the widget.
+    """
+
+    def __init__(self, monkeypatch, start: float = 0.0):
+        self.now = start
+        monkeypatch.setattr(time, "monotonic", lambda: self.now)
+
+    def advance(self, dt: float) -> None:
+        self.now += dt
+
+    def drive(self, widget, dt: float, n: int = 1) -> None:
+        """Advance the clock by dt and tick the widget, n times."""
+        for _ in range(n):
+            self.advance(dt)
+            widget.tick()
+
+@pytest.fixture
+def fake_clock(monkeypatch):
+    return FakeClock(monkeypatch)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Protocol
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -234,35 +235,26 @@ def fake_lcd():
     return FakeLcd()
 
 
-# ---------------------------------------------------------------------------
-# FakeClock — deterministic wall time for tick-driven animations
-# ---------------------------------------------------------------------------
+class Tickable(Protocol):
+    def tick(self) -> None: ...
 
 
 class FakeClock:
-    """Deterministic time.monotonic for tick-driven animations.
-
-    Patches every module that reads the wall clock for animation pacing
-    (they all share the stdlib time module, so one attribute carries all
-    of them). ``drive(widget, dt, n)`` simulates n mainloop passes:
-    advance the clock by dt, then tick the widget.
-    """
-
-    def __init__(self, monkeypatch, start: float = 0.0):
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, start: float = 0.0) -> None:
         self.now = start
         monkeypatch.setattr(time, "monotonic", lambda: self.now)
 
     def advance(self, dt: float) -> None:
         self.now += dt
 
-    def drive(self, widget, dt: float, n: int = 1) -> None:
-        """Advance the clock by dt and tick the widget, n times."""
+    def drive(self, widget: Tickable, dt: float, n: int = 1) -> None:
         for _ in range(n):
             self.advance(dt)
             widget.tick()
 
+
 @pytest.fixture
-def fake_clock(monkeypatch):
+def fake_clock(monkeypatch: pytest.MonkeyPatch) -> FakeClock:
     return FakeClock(monkeypatch)
 
 

--- a/tests/test_lcd320x240.py
+++ b/tests/test_lcd320x240.py
@@ -832,3 +832,124 @@ def test_tall_parallel_scrolled_to_last(lcd, snapshot):
     for _ in range(col0_count - 1 + 3):
         instance.main_panel.sel_next()
     snapshot("scrolled_to_last")
+
+
+@pytest.fixture
+def long_title_lcd(lcd, fake_clock):
+    """Main panel with a pedalboard title long enough to overflow its box.
+
+    draw_main_panel auto-selects w_pedalboard on pedalboard load; nav to the
+    wrench elsewhere so the tests control selection explicitly. The clock is
+    warmed past SUBTITLE_TIMEOUT so the nav-change subtitle (a legitimate
+    one-frame LCD push) has already shown and hidden, and any later frame
+    can only come from scrolling.
+    """
+    instance, fake = lcd
+    pb = _make_pedalboard("The Extremely Long Pedalboard Name That Will Not Fit", [], [])
+    _setup_pedalboard(instance, pb)
+    instance.main_panel.sel_widget(instance.w_wrench)
+    for _ in range(20):  # 1.6s > SUBTITLE_TIMEOUT (1.3s)
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    fake.frames.clear()
+    return instance, fake
+
+
+def test_long_title_is_quiescent_until_selected(long_title_lcd, fake_clock):
+    """SPI traffic is audible on the DAC at high gain, so an unselected
+    overflow title must generate zero LCD pushes, however long you wait."""
+    instance, fake = long_title_lcd
+    title = instance.w_pedalboard
+    assert title is not None and title._should_scroll()
+
+    for _ in range(100):  # ~2.5 cycles worth of ticks
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert fake.frames == []
+    assert title.scroll_offset == 0
+
+
+def test_long_title_scrolls_only_while_selected(long_title_lcd, fake_clock):
+    """NAV onto the overflow title is the one thing that may animate it —
+    and leaving it parks the text back at its start."""
+    instance, fake = long_title_lcd
+    title = instance.w_pedalboard
+    assert title is not None
+
+    def settle():
+        """Run past the nav subtitle's show/hide window, then drop its frames."""
+        for _ in range(20):
+            fake_clock.advance(0.08)
+            instance._poll_updates()
+        fake.frames.clear()
+
+    # Nothing moves while the wrench holds selection.
+    for _ in range(25):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert title.scroll_offset == 0
+    assert fake.frames == []
+
+    # NAV right from the wrench reaches the title (it follows the toolbar).
+    instance.main_panel.input_step(1, 1, 1.0)
+    assert instance.main_panel.sel_ref is title
+    assert title.selected
+    settle()
+
+    # Mid-cycle, the title is scrolling and pushing frames.
+    for _ in range(35):  # past the 2s start pause, into the scroll phase
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert title.scroll_offset > 0
+    assert len(fake.frames) > 0
+
+    # NAV away: snapped home immediately, and quiescent again.
+    instance.main_panel.input_step(1, 1, 1.0)
+    assert not title.selected
+    assert title.scroll_offset == 0
+    settle()
+    for _ in range(50):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert fake.frames == []
+    assert title.scroll_offset == 0
+    fake.frames.clear()
+
+
+def test_at_most_one_title_scrolls(long_title_lcd, fake_clock):
+    """Both title widgets overflow, yet the invariant holds: 0 or 1 moving."""
+    instance, _ = long_title_lcd
+    instance.draw_preset("An Equally Long Snapshot Name That Overflows")
+    pb_title = instance.w_pedalboard
+    preset_title = instance.w_preset
+    assert pb_title is not None and preset_title is not None
+    assert pb_title._should_scroll() and preset_title._should_scroll()
+
+    def moving():
+        return [w for w in (pb_title, preset_title) if w.scroll_offset != 0]
+
+    # Park selection on a neutral widget first.
+    instance.main_panel.sel_widget(instance.w_wrench)
+    for _ in range(100):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert moving() == []
+
+    # Sweep the whole title cycle under selection: at most one mover at any
+    # sample, and each title's move comes only from its own selection.
+    instance.main_panel.sel_widget(pb_title)
+    for _ in range(120):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+        assert len(moving()) <= 1
+        assert preset_title.scroll_offset == 0
+    assert pb_title.scroll_offset > 0  # sanity: it did scroll
+
+    instance.main_panel.sel_widget(preset_title)
+    assert pb_title.scroll_offset == 0  # snapped on the nav itself
+    for _ in range(120):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+        assert len(moving()) <= 1
+        assert pb_title.scroll_offset == 0
+    assert preset_title.scroll_offset > 0

--- a/tests/test_lcd320x240.py
+++ b/tests/test_lcd320x240.py
@@ -836,33 +836,23 @@ def test_tall_parallel_scrolled_to_last(lcd, snapshot):
 
 @pytest.fixture
 def long_title_lcd(lcd, fake_clock):
-    """Main panel with a pedalboard title long enough to overflow its box.
-
-    draw_main_panel auto-selects w_pedalboard on pedalboard load; nav to the
-    wrench elsewhere so the tests control selection explicitly. The clock is
-    warmed past SUBTITLE_TIMEOUT so the nav-change subtitle (a legitimate
-    one-frame LCD push) has already shown and hidden, and any later frame
-    can only come from scrolling.
-    """
     instance, fake = lcd
     pb = _make_pedalboard("The Extremely Long Pedalboard Name That Will Not Fit", [], [])
     _setup_pedalboard(instance, pb)
     instance.main_panel.sel_widget(instance.w_wrench)
-    for _ in range(20):  # 1.6s > SUBTITLE_TIMEOUT (1.3s)
+    for _ in range(20):
         fake_clock.advance(0.08)
         instance._poll_updates()
     fake.frames.clear()
     return instance, fake
 
 
-def test_long_title_is_quiescent_until_selected(long_title_lcd, fake_clock):
-    """SPI traffic is audible on the DAC at high gain, so an unselected
-    overflow title must generate zero LCD pushes, however long you wait."""
+def test_long_title_stays_still_until_selected(long_title_lcd, fake_clock):
     instance, fake = long_title_lcd
     title = instance.w_pedalboard
     assert title is not None and title._should_scroll()
 
-    for _ in range(100):  # ~2.5 cycles worth of ticks
+    for _ in range(100):
         fake_clock.advance(0.08)
         instance._poll_updates()
     assert fake.frames == []
@@ -870,40 +860,33 @@ def test_long_title_is_quiescent_until_selected(long_title_lcd, fake_clock):
 
 
 def test_long_title_scrolls_only_while_selected(long_title_lcd, fake_clock):
-    """NAV onto the overflow title is the one thing that may animate it —
-    and leaving it parks the text back at its start."""
     instance, fake = long_title_lcd
     title = instance.w_pedalboard
     assert title is not None
 
     def settle():
-        """Run past the nav subtitle's show/hide window, then drop its frames."""
         for _ in range(20):
             fake_clock.advance(0.08)
             instance._poll_updates()
         fake.frames.clear()
 
-    # Nothing moves while the wrench holds selection.
     for _ in range(25):
         fake_clock.advance(0.08)
         instance._poll_updates()
     assert title.scroll_offset == 0
     assert fake.frames == []
 
-    # NAV right from the wrench reaches the title (it follows the toolbar).
     instance.main_panel.input_step(1, 1, 1.0)
     assert instance.main_panel.sel_ref is title
     assert title.selected
     settle()
 
-    # Mid-cycle, the title is scrolling and pushing frames.
-    for _ in range(35):  # past the 2s start pause, into the scroll phase
+    for _ in range(35):
         fake_clock.advance(0.08)
         instance._poll_updates()
     assert title.scroll_offset > 0
     assert len(fake.frames) > 0
 
-    # NAV away: snapped home immediately, and quiescent again.
     instance.main_panel.input_step(1, 1, 1.0)
     assert not title.selected
     assert title.scroll_offset == 0
@@ -916,8 +899,26 @@ def test_long_title_scrolls_only_while_selected(long_title_lcd, fake_clock):
     fake.frames.clear()
 
 
+def test_title_does_not_tick_off_main_panel(long_title_lcd, fake_clock):
+    instance, fake = long_title_lcd
+    title = instance.w_pedalboard
+    assert title is not None
+    instance.main_panel.sel_widget(title)
+    for _ in range(35):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert title.scroll_offset > 0
+    fake.frames.clear()
+
+    instance.pstack.current = None
+    offset = title.scroll_offset
+    for _ in range(50):
+        fake_clock.advance(0.08)
+        instance._poll_updates()
+    assert title.scroll_offset == offset
+    assert fake.frames == []
+
 def test_at_most_one_title_scrolls(long_title_lcd, fake_clock):
-    """Both title widgets overflow, yet the invariant holds: 0 or 1 moving."""
     instance, _ = long_title_lcd
     instance.draw_preset("An Equally Long Snapshot Name That Overflows")
     pb_title = instance.w_pedalboard
@@ -928,25 +929,22 @@ def test_at_most_one_title_scrolls(long_title_lcd, fake_clock):
     def moving():
         return [w for w in (pb_title, preset_title) if w.scroll_offset != 0]
 
-    # Park selection on a neutral widget first.
     instance.main_panel.sel_widget(instance.w_wrench)
     for _ in range(100):
         fake_clock.advance(0.08)
         instance._poll_updates()
     assert moving() == []
 
-    # Sweep the whole title cycle under selection: at most one mover at any
-    # sample, and each title's move comes only from its own selection.
     instance.main_panel.sel_widget(pb_title)
     for _ in range(120):
         fake_clock.advance(0.08)
         instance._poll_updates()
         assert len(moving()) <= 1
         assert preset_title.scroll_offset == 0
-    assert pb_title.scroll_offset > 0  # sanity: it did scroll
+    assert pb_title.scroll_offset > 0
 
     instance.main_panel.sel_widget(preset_title)
-    assert pb_title.scroll_offset == 0  # snapped on the nav itself
+    assert pb_title.scroll_offset == 0
     for _ in range(120):
         fake_clock.advance(0.08)
         instance._poll_updates()

--- a/tests/test_scrolling_text.py
+++ b/tests/test_scrolling_text.py
@@ -1,0 +1,227 @@
+"""
+ScrollingText selection gating.
+
+Every scroll step is a repaint, repaints are SPI traffic, and SPI traffic is
+audible on the DAC at high gain. So a long title must not animate by default:
+ping-pong auto-scroll runs only while the widget is the one NAV selected, and
+an unselected widget sits snapped at the text's start. Exactly 0 or 1
+ScrollingTexts animate at any moment, with no extra state — the widget's own
+`selected` flag (maintained by the panel's nav machinery) is the whole gate.
+
+Contracts verified here:
+  - unselected widgets never advance the scroll offset, at any clock time
+  - a selected widget ping-pongs 0 -> max -> 0 and parks at each end
+  - deselection snaps back to the leftmost position immediately
+  - text that fits never scrolls
+  - a real Panel with two overflow titles has at most one scroller moving
+"""
+
+import pytest
+
+from common.fonts import font_path
+from tests.conftest import FakeClock
+from uilib.box import Box
+from uilib.panel import Panel
+from uilib.pygame_init import font as make_font
+from uilib.text import ScrollingText
+
+
+LONG = "The Extremely Long Pedalboard Name That Will Not Fit"
+SHORT = "Rig"
+
+# A tick cadence well under the 0.25s re-anchor gap so ticks look continuous
+# to the widget, letting the test sweep a whole cycle in coarse steps.
+DT = 0.1
+
+
+@pytest.fixture
+def font():
+    """A fresh font per test: emulator suites quit pygame mid-session, which
+    invalidates any font created earlier (including at import time)."""
+    return make_font(font_path("DejaVuSans.ttf"), 26)
+
+
+def make_text(font, text=LONG, width=60, parent=None):
+    w = ScrollingText(
+        box=Box.xywh(0, 0, width, 36),
+        text=text,
+        font=font,
+        parent=parent,
+    )
+    assert w.box is not None
+    return w
+
+
+def make_panel():
+    p = Panel(box=Box.xywh(0, 0, 320, 240))
+    p.visible = True
+    return p
+
+
+def max_offset_of(w):
+    h_margin, _ = w._get_margins()
+    return w.cached_text_width - (w.box.width - h_margin - w.outline)
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    return FakeClock(monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# The gate: unselected widgets never move
+# ---------------------------------------------------------------------------
+
+
+def test_unselected_never_scrolls(clock, font):
+    w = make_text(font)
+    w._render_text_to_cache()
+    assert w._should_scroll(), "fixture must overflow"
+
+    # A full cycle plus change, ticked as if the mainloop were running.
+    end = w.pause_start_sec + (max_offset_of(w) / w.pixels_per_second) * 2 + w.pause_end_sec + 5.0
+    t = 0.0
+    while t < end:
+        t += DT
+        clock.now = t
+        w.tick()
+        assert w.scroll_offset == 0, f"unselected widget scrolled to {w.scroll_offset} at t={t}"
+
+
+def test_hidden_never_scrolls(clock, font):
+    w = make_text(font)
+    w.selected = True
+    w.visible = False
+    clock.drive(w, DT, n=60)
+    assert w.scroll_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# Selected widgets ping-pong
+# ---------------------------------------------------------------------------
+
+
+def test_selected_scrolls_and_pingpongs(clock, font):
+    w = make_text(font)
+    w._render_text_to_cache()
+    w.selected = True
+
+    max_off = max_offset_of(w)
+    scroll_dur = max_off / w.pixels_per_second
+
+    # First tick anchors the cycle; every phase boundary below is relative
+    # to that anchor, not to zero.
+    clock.drive(w, DT)
+    t0 = clock.now
+
+    # Through the start pause: parked at 0.
+    while clock.now < t0 + w.pause_start_sec:
+        clock.drive(w, DT)
+    assert w.scroll_offset == 0
+
+    # Down the text: rising monotonically to max.
+    last = 0
+    t_end = t0 + w.pause_start_sec + scroll_dur
+    while clock.now < t_end:
+        clock.drive(w, DT)
+        assert w.scroll_offset >= last
+        last = w.scroll_offset
+    clock.now = t_end
+    w.tick()
+    assert w.scroll_offset == max_off
+
+    # The end pause: parked at max.
+    while clock.now < t_end + w.pause_end_sec:
+        clock.drive(w, DT)
+    assert w.scroll_offset == max_off
+
+    # And back home to exactly 0 by the end of the return phase.
+    t_home = t_end + w.pause_end_sec + scroll_dur
+    while clock.now < t_home:
+        clock.drive(w, DT)
+    clock.now = t_home
+    w.tick()
+    assert w.scroll_offset == 0
+
+
+def test_text_that_fits_never_scrolls(clock, font):
+    w = make_text(font, text=SHORT, width=200)
+    w.selected = True
+    clock.drive(w, DT, n=100)
+    assert w.scroll_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# Snap home on deselect
+# ---------------------------------------------------------------------------
+
+
+def test_deselect_snaps_home_and_stays(clock, font):
+    w = make_text(font)
+    w._render_text_to_cache()
+    w.selected = True
+
+    # Scroll to the far end of the text.
+    max_off = max_offset_of(w)
+    clock.drive(w, DT)
+    t0 = clock.now
+    while clock.now < t0 + w.pause_start_sec + max_off / w.pixels_per_second:
+        clock.drive(w, DT)
+    assert w.scroll_offset == max_off
+
+    # Deselect: parked at the leftmost position immediately, in the same
+    # repaint that drops the selection reticule.
+    w.set_selected(False)
+    assert w.scroll_offset == 0
+
+    # And it stays there, forever, for free.
+    clock.drive(w, DT, n=200)
+    assert w.scroll_offset == 0
+    assert w._anchor_time is None
+
+
+# ---------------------------------------------------------------------------
+# The invariant, against the real panel selection machinery
+# ---------------------------------------------------------------------------
+
+
+def test_panel_selection_moves_the_single_scroller(clock, font):
+    panel = make_panel()
+    a = make_text(font, parent=panel, width=60)
+    b = make_text(font, parent=panel, width=60)
+    panel.add_sel_widget(a)
+    panel.add_sel_widget(b)
+    panel.sel_ref = a
+    a.selected = True
+    a._render_text_to_cache()
+    b._render_text_to_cache()
+
+    def offsets():
+        return (a.scroll_offset, b.scroll_offset)
+
+    # First selection: exactly one widget may animate.
+    clock.drive(a, DT, n=int((a.pause_start_sec + max_offset_of(a) / a.pixels_per_second * 0.5) / DT))
+    oa, ob = offsets()
+    assert oa > 0
+    assert ob == 0
+
+    # NAV to the second: the first snapped home, the second took over.
+    panel.sel_widget(b)
+    clock.drive(b, DT, n=int((b.pause_start_sec + max_offset_of(b) / b.pixels_per_second * 0.5) / DT))
+    assert a.scroll_offset == 0
+    assert b.scroll_offset > 0
+
+    # NAV off both (a menu is open; the title widgets lose selection):
+    # nothing animates at all.
+    panel.sel_widget(_plain_widget(panel, font))
+    clock.drive(a, DT, n=50)
+    clock.drive(b, DT, n=50)
+    assert offsets() == (0, 0)
+
+
+def _plain_widget(panel, font):
+    from uilib.text import TextWidget
+
+    w = TextWidget(box=Box.xywh(0, 100, 60, 36), text="plain", font=font, parent=panel)
+    panel.add_sel_widget(w)
+    return w

--- a/tests/test_scrolling_text.py
+++ b/tests/test_scrolling_text.py
@@ -1,20 +1,3 @@
-"""
-ScrollingText selection gating.
-
-Every scroll step is a repaint, repaints are SPI traffic, and SPI traffic is
-audible on the DAC at high gain. So a long title must not animate by default:
-ping-pong auto-scroll runs only while the widget is the one NAV selected, and
-an unselected widget sits snapped at the text's start. Exactly 0 or 1
-ScrollingTexts animate at any moment, with no extra state — the widget's own
-`selected` flag (maintained by the panel's nav machinery) is the whole gate.
-
-Contracts verified here:
-  - unselected widgets never advance the scroll offset, at any clock time
-  - a selected widget ping-pongs 0 -> max -> 0 and parks at each end
-  - deselection snaps back to the leftmost position immediately
-  - text that fits never scrolls
-  - a real Panel with two overflow titles has at most one scroller moving
-"""
 
 import pytest
 
@@ -29,15 +12,11 @@ from uilib.text import ScrollingText
 LONG = "The Extremely Long Pedalboard Name That Will Not Fit"
 SHORT = "Rig"
 
-# A tick cadence well under the 0.25s re-anchor gap so ticks look continuous
-# to the widget, letting the test sweep a whole cycle in coarse steps.
 DT = 0.1
 
 
 @pytest.fixture
 def font():
-    """A fresh font per test: emulator suites quit pygame mid-session, which
-    invalidates any font created earlier (including at import time)."""
     return make_font(font_path("DejaVuSans.ttf"), 26)
 
 
@@ -68,9 +47,6 @@ def clock(monkeypatch):
     return FakeClock(monkeypatch)
 
 
-# ---------------------------------------------------------------------------
-# The gate: unselected widgets never move
-# ---------------------------------------------------------------------------
 
 
 def test_unselected_never_scrolls(clock, font):
@@ -78,7 +54,6 @@ def test_unselected_never_scrolls(clock, font):
     w._render_text_to_cache()
     assert w._should_scroll(), "fixture must overflow"
 
-    # A full cycle plus change, ticked as if the mainloop were running.
     end = w.pause_start_sec + (max_offset_of(w) / w.pixels_per_second) * 2 + w.pause_end_sec + 5.0
     t = 0.0
     while t < end:
@@ -96,9 +71,6 @@ def test_hidden_never_scrolls(clock, font):
     assert w.scroll_offset == 0
 
 
-# ---------------------------------------------------------------------------
-# Selected widgets ping-pong
-# ---------------------------------------------------------------------------
 
 
 def test_selected_scrolls_and_pingpongs(clock, font):
@@ -109,17 +81,13 @@ def test_selected_scrolls_and_pingpongs(clock, font):
     max_off = max_offset_of(w)
     scroll_dur = max_off / w.pixels_per_second
 
-    # First tick anchors the cycle; every phase boundary below is relative
-    # to that anchor, not to zero.
     clock.drive(w, DT)
     t0 = clock.now
 
-    # Through the start pause: parked at 0.
     while clock.now < t0 + w.pause_start_sec:
         clock.drive(w, DT)
     assert w.scroll_offset == 0
 
-    # Down the text: rising monotonically to max.
     last = 0
     t_end = t0 + w.pause_start_sec + scroll_dur
     while clock.now < t_end:
@@ -130,12 +98,10 @@ def test_selected_scrolls_and_pingpongs(clock, font):
     w.tick()
     assert w.scroll_offset == max_off
 
-    # The end pause: parked at max.
     while clock.now < t_end + w.pause_end_sec:
         clock.drive(w, DT)
     assert w.scroll_offset == max_off
 
-    # And back home to exactly 0 by the end of the return phase.
     t_home = t_end + w.pause_end_sec + scroll_dur
     while clock.now < t_home:
         clock.drive(w, DT)
@@ -151,9 +117,6 @@ def test_text_that_fits_never_scrolls(clock, font):
     assert w.scroll_offset == 0
 
 
-# ---------------------------------------------------------------------------
-# Snap home on deselect
-# ---------------------------------------------------------------------------
 
 
 def test_deselect_snaps_home_and_stays(clock, font):
@@ -161,7 +124,6 @@ def test_deselect_snaps_home_and_stays(clock, font):
     w._render_text_to_cache()
     w.selected = True
 
-    # Scroll to the far end of the text.
     max_off = max_offset_of(w)
     clock.drive(w, DT)
     t0 = clock.now
@@ -169,20 +131,14 @@ def test_deselect_snaps_home_and_stays(clock, font):
         clock.drive(w, DT)
     assert w.scroll_offset == max_off
 
-    # Deselect: parked at the leftmost position immediately, in the same
-    # repaint that drops the selection reticule.
     w.set_selected(False)
     assert w.scroll_offset == 0
 
-    # And it stays there, forever, for free.
     clock.drive(w, DT, n=200)
     assert w.scroll_offset == 0
     assert w._anchor_time is None
 
 
-# ---------------------------------------------------------------------------
-# The invariant, against the real panel selection machinery
-# ---------------------------------------------------------------------------
 
 
 def test_panel_selection_moves_the_single_scroller(clock, font):
@@ -199,20 +155,16 @@ def test_panel_selection_moves_the_single_scroller(clock, font):
     def offsets():
         return (a.scroll_offset, b.scroll_offset)
 
-    # First selection: exactly one widget may animate.
     clock.drive(a, DT, n=int((a.pause_start_sec + max_offset_of(a) / a.pixels_per_second * 0.5) / DT))
     oa, ob = offsets()
     assert oa > 0
     assert ob == 0
 
-    # NAV to the second: the first snapped home, the second took over.
     panel.sel_widget(b)
     clock.drive(b, DT, n=int((b.pause_start_sec + max_offset_of(b) / b.pixels_per_second * 0.5) / DT))
     assert a.scroll_offset == 0
     assert b.scroll_offset > 0
 
-    # NAV off both (a menu is open; the title widgets lose selection):
-    # nothing animates at all.
     panel.sel_widget(_plain_widget(panel, font))
     clock.drive(a, DT, n=50)
     clock.drive(b, DT, n=50)

--- a/uilib/text.py
+++ b/uilib/text.py
@@ -548,14 +548,22 @@ class PluginTile(TextWidget):
 
 
 class ScrollingText(TextWidget):
-    """TextWidget with horizontal ping-pong scrolling for overflow text."""
+    """TextWidget that ping-pong-scrolls overflowing text — but only while it
+    is the selected widget; otherwise it sits snapped to the text's start.
+
+    Scrolling is driven by ``tick()`` and gated on the plain ``selected`` flag
+    that NAV already maintains, so no extra state or wiring exists: at most one
+    ScrollingText (the NAV selection) ever animates. Every step is a repaint,
+    repaints are SPI traffic, and SPI traffic is audible on the DAC at high
+    gain — so a long title must be opt-in to scroll rather than animate by
+    default.
+    """
 
     def __init__(
         self,
         pixels_per_second: float = 50.0,
         pause_start_sec: float = 2.0,
         pause_end_sec: float = 1.0,
-        lcd_poll_divisor: int = 8,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -596,31 +604,44 @@ class ScrollingText(TextWidget):
             self.font.origin = prev
         self.cached_text_image = surf
 
+    def _scroll_hroom(self) -> int:
+        """The visible text window: box width minus one h_margin and the
+        outline — the same rectangle the crop blit in ``_draw`` paints into
+        and the static branch leaves for text. One measurement everywhere,
+        else the ping never lands on the text's true end."""
+        assert self.box is not None
+        h_margin, _ = self._get_margins()
+        return self.box.width - h_margin - self.outline
+
     def _should_scroll(self) -> bool:
         if self.cached_text_image is None:
             return False
-        assert self.box is not None
-        h_margin, _ = self._get_margins()
-        available_width = self.box.width - h_margin - self.outline
-        return self.cached_text_width > available_width
+        return self.cached_text_width > self._scroll_hroom()
+
+    @override
+    def set_selected(self, selected: bool) -> None:
+        # Snap home *before* the deselect repaint so the reticule leaving and
+        # the text parking land in a single push — a mid-scroll deselect must
+        # not pay two LCD transfers, the second being a stale-offset frame.
+        if not selected:
+            self._snap_home()
+        super().set_selected(selected)
 
     @override
     def tick(self) -> None:
         if self.cached_text_image is None:
             self._render_text_to_cache()
 
-        if not self._should_scroll():
-            if self.scroll_offset != 0:
-                self.scroll_offset = 0
-                self._anchor_time = None
-                self._last_tick_time = None
-                self.refresh()
+        # The tick's job is to advance a selected, visible overflow; anything
+        # else is already parked (set_selected snaps home), so the gate is a
+        # pure safety net — cheap, and it short-circuits before the box
+        # asserts in _should_scroll.
+        if not self.selected or not self.visible or not self._should_scroll():
+            self._snap_home()
             return
 
-        assert self.box is not None
-        h_margin, _ = self._get_margins()
-        available_width = self.box.width - 2 * h_margin - self.outline
-        max_offset = self.cached_text_width - available_width
+        hroom = self._scroll_hroom()
+        max_offset = self.cached_text_width - hroom
         if max_offset <= 0:
             return
 
@@ -651,13 +672,22 @@ class ScrollingText(TextWidget):
             self.scroll_offset = new_offset
             self.refresh()
 
+    def _snap_home(self) -> None:
+        """Park at the text's start and reset the cycle, so a re-select always
+        begins with the start pause. Repaints only if pixels actually moved —
+        a quiescent widget generates no SPI traffic."""
+        if self.scroll_offset != 0:
+            self.scroll_offset = 0
+            self.refresh()
+        self._anchor_time = None
+        self._last_tick_time = None
+
     def _clear_cache_and_restart(self) -> None:
         self.cached_text_image = None
         self.scroll_offset = 0
         self._anchor_time = None
         self._last_tick_time = None
 
-    @override
     def set_foreground(self, color) -> None:
         self._clear_cache_and_restart()
         super().set_foreground(color)
@@ -702,6 +732,10 @@ class ScrollingText(TextWidget):
             src_rect = pygame.Rect(0, 0, min(tw, hroom), th)
             ctx.surface.blit(self.cached_text_image, (h_margin + hoffset + ox, v_margin + oy), src_rect)
         else:
+            # Overflow: left-anchored crop at the current scroll offset,
+            # which tick keeps at 0 unless this widget is selected — the
+            # unselected rest state and offset 0 render identically, so
+            # selection changes never jump the text.
             crop_width = min(hroom, self.cached_text_width - self.scroll_offset)
             src_rect = pygame.Rect(self.scroll_offset, 0, crop_width, th)
             ctx.surface.blit(self.cached_text_image, (h_margin + ox, v_margin + oy), src_rect)

--- a/uilib/text.py
+++ b/uilib/text.py
@@ -229,8 +229,17 @@ class TextWidget(Widget):
     font: "pygame._freetype.Font"
 
     def __init__(
-        self, box, text="", font=None, edit_message=None, h_margin=None, v_margin=None, text_halign=None,
-        badge: "BadgeGlyph | None" = None, badge_gap: int = 3, **kwargs
+        self,
+        box,
+        text="",
+        font=None,
+        edit_message=None,
+        h_margin=None,
+        v_margin=None,
+        text_halign=None,
+        badge: "BadgeGlyph | None" = None,
+        badge_gap: int = 3,
+        **kwargs,
     ):
         self.text = text
         if font is None:
@@ -478,7 +487,15 @@ class PluginTile(TextWidget):
     widget must fully, opaquely cover its own rect.
     """
 
-    def __init__(self, *, plugin: "Plugin", border: RectBorder | None = None, backdrop: tuple[int, int, int] = (0, 0, 0), foreground: tuple[int, int, int] = (255, 255, 255), **kwargs):
+    def __init__(
+        self,
+        *,
+        plugin: "Plugin",
+        border: RectBorder | None = None,
+        backdrop: tuple[int, int, int] = (0, 0, 0),
+        foreground: tuple[int, int, int] = (255, 255, 255),
+        **kwargs,
+    ):
         self._custom_border = border
         self._backdrop = backdrop
         self._foreground = foreground
@@ -548,16 +565,7 @@ class PluginTile(TextWidget):
 
 
 class ScrollingText(TextWidget):
-    """TextWidget that ping-pong-scrolls overflowing text — but only while it
-    is the selected widget; otherwise it sits snapped to the text's start.
-
-    Scrolling is driven by ``tick()`` and gated on the plain ``selected`` flag
-    that NAV already maintains, so no extra state or wiring exists: at most one
-    ScrollingText (the NAV selection) ever animates. Every step is a repaint,
-    repaints are SPI traffic, and SPI traffic is audible on the DAC at high
-    gain — so a long title must be opt-in to scroll rather than animate by
-    default.
-    """
+    """TextWidget that ping-pong scrolls its contents when selected."""
 
     def __init__(
         self,
@@ -605,10 +613,6 @@ class ScrollingText(TextWidget):
         self.cached_text_image = surf
 
     def _scroll_hroom(self) -> int:
-        """The visible text window: box width minus one h_margin and the
-        outline — the same rectangle the crop blit in ``_draw`` paints into
-        and the static branch leaves for text. One measurement everywhere,
-        else the ping never lands on the text's true end."""
         assert self.box is not None
         h_margin, _ = self._get_margins()
         return self.box.width - h_margin - self.outline
@@ -620,22 +624,23 @@ class ScrollingText(TextWidget):
 
     @override
     def set_selected(self, selected: bool) -> None:
-        # Snap home *before* the deselect repaint so the reticule leaving and
-        # the text parking land in a single push — a mid-scroll deselect must
-        # not pay two LCD transfers, the second being a stale-offset frame.
         if not selected:
-            self._snap_home()
+            self._snap_home(refresh=False)
         super().set_selected(selected)
+
+    def _snap_home(self, refresh: bool = True) -> None:
+        if self.scroll_offset != 0:
+            self.scroll_offset = 0
+            if refresh:
+                self.refresh()
+        self._anchor_time = None
+        self._last_tick_time = None
 
     @override
     def tick(self) -> None:
         if self.cached_text_image is None:
             self._render_text_to_cache()
 
-        # The tick's job is to advance a selected, visible overflow; anything
-        # else is already parked (set_selected snaps home), so the gate is a
-        # pure safety net — cheap, and it short-circuits before the box
-        # asserts in _should_scroll.
         if not self.selected or not self.visible or not self._should_scroll():
             self._snap_home()
             return
@@ -649,8 +654,6 @@ class ScrollingText(TextWidget):
         period = self.pause_start_sec + scroll_duration + self.pause_end_sec + scroll_duration
 
         now = time.monotonic()
-        # On first tick, or after a wild gap (process paused, panel hidden),
-        # re-anchor so we start a fresh cycle at the initial pause.
         if self._anchor_time is None or (self._last_tick_time is not None and now - self._last_tick_time > 0.25):
             self._anchor_time = now
         self._last_tick_time = now
@@ -672,22 +675,13 @@ class ScrollingText(TextWidget):
             self.scroll_offset = new_offset
             self.refresh()
 
-    def _snap_home(self) -> None:
-        """Park at the text's start and reset the cycle, so a re-select always
-        begins with the start pause. Repaints only if pixels actually moved —
-        a quiescent widget generates no SPI traffic."""
-        if self.scroll_offset != 0:
-            self.scroll_offset = 0
-            self.refresh()
-        self._anchor_time = None
-        self._last_tick_time = None
-
     def _clear_cache_and_restart(self) -> None:
         self.cached_text_image = None
         self.scroll_offset = 0
         self._anchor_time = None
         self._last_tick_time = None
 
+    @override
     def set_foreground(self, color) -> None:
         self._clear_cache_and_restart()
         super().set_foreground(color)
@@ -732,10 +726,6 @@ class ScrollingText(TextWidget):
             src_rect = pygame.Rect(0, 0, min(tw, hroom), th)
             ctx.surface.blit(self.cached_text_image, (h_margin + hoffset + ox, v_margin + oy), src_rect)
         else:
-            # Overflow: left-anchored crop at the current scroll offset,
-            # which tick keeps at 0 unless this widget is selected — the
-            # unselected rest state and offset 0 render identically, so
-            # selection changes never jump the text.
             crop_width = min(hroom, self.cached_text_width - self.scroll_offset)
             src_rect = pygame.Rect(self.scroll_offset, 0, crop_width, th)
             ctx.surface.blit(self.cached_text_image, (h_margin + ox, v_margin + oy), src_rect)


### PR DESCRIPTION
SPI transfers cause small bursts of noise on ADC inputs. These are usually completely inaudible, but some high-gain amplifiers and NAM models can make these transfers audible. This is normally fine: you're unlikely to be interacting with the screen when playing. However, it does mean that any animations on the screen can cause persistent noise.

This PR makes it so that these widgets only scroll when they're highlighted, giving users a way to avoid the noise if it's affecting them.

Potentially closes https://github.com/TreeFallSound/pi-gen-pistomp/issues/46

### Author checklist

- [x] re-write llm slop
