### PR TITLE
Ensure that parameter commits happen (loading end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The parameter dialog on the LCD sometimes did not change values due to a race condition with respect to MOD-UI's `last.json`. pi-Stomp then did not send parameter changes to MOD-UI until you selected a different pedalboard. Parameters on a knob or an encoder continued to work, because they send MIDI CC.
+- The LCD showed a bypass that MOD-UI did not receive, if you tapped it while a pedalboard loaded. The LCD now keeps the last value that MOD-UI confirmed.
+- A parameter change from a plugin menu could be lost if the connection to MOD-UI was busy. pi-Stomp now sends the value again on the next cycle.
 
 ## [v3.3.1] - 2026-09-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The parameter dialog on the LCD sometimes did not change values due to a race condition with respect to MOD-UI's `last.json`. pi-Stomp then did not send parameter changes to MOD-UI until you selected a different pedalboard. Parameters on a knob or an encoder continued to work, because they send MIDI CC.
 - The LCD showed a bypass that MOD-UI did not receive, if you tapped it while a pedalboard loaded. The LCD now keeps the last value that MOD-UI confirmed.
 - A parameter change from a plugin menu could be lost if the connection to MOD-UI was busy. pi-Stomp now sends the value again on the next cycle.
+- The bypass button in a plugin menu did not agree with the footswitch LED, if the plugin had a footswitch. Every bypass is now one action, and the LED follows it.
 
 ## [v3.3.1] - 2026-09-01
 ### Added

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -112,10 +112,23 @@ uv-managed venv. Don't try to pip-install the system ones.
   socket, and mod-host emits no `param_set` for bypasses it received from mod-ui. So
   that path must update local state itself: `Plugin.toggle_bypass` commits, which
   writes and publishes as one act and reverts if the send never leaves. A
-  footswitch-bound plugin is the opposite: `toggle_plugin_bypass` routes through the
-  footswitch press path, which sends MIDI CC → mod-host → feedback echo, and that echo
-  reconciles it. The asymmetry is deliberate, not a bug to "fix." Every bypass — LCD
-  tile, plugin panel button, footswitch — goes through `Handler.toggle_plugin_bypass`.
+  footswitch-bound plugin is the opposite: `_sink_for` routes its commit out as MIDI
+  CC → mod-host → feedback echo, and that echo reconciles it. The asymmetry is one of
+  *transport*, chosen by `_sink_for`, and it is deliberate.
+
+  Dispatch carries no such fork. Every UI bypass — LCD tile, plugin panel button — is
+  one commit on `:bypass`, and the keycap follows because `StatefulController`
+  subscribes to the settled value. Never reach the wire by faking a press: the row
+  that wins that switch need not be the bypass. The press is its own path — a preview
+  plus the emit in `_fire_row`'s `ParamEffect` arm — because it already knows its
+  transport and has no sink to choose.
+
+- **A switch's CC carries only the two ends of the binding range.** mod-ui's advanced
+  MIDI-learn menu puts a footswitch on a continuous parameter with its own min/max,
+  and a press alternates between exactly those. A UI edit that lands *between* them
+  has no CC code, so `_publish_switch_cc` sends it over the WebSocket instead — else
+  mod-host answers an endpoint against a screen showing the real value. Pinned by the
+  endpoint pair in `tests/v3/test_sink_routing.py`.
 
 - **`loading_start` opens a window that suppresses outbound sends; `loading_end`
   closes it.** Both come from mod-ui, in pairs, from a board load and from the

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -110,10 +110,21 @@ uv-managed venv. Don't try to pip-install the system ones.
 
 - **A UI bypass of a footswitch-less plugin gets no echo.** mod-ui skips the origin
   socket, and mod-host emits no `param_set` for bypasses it received from mod-ui. So
-  that path must update local state itself (`toggle_plugin_bypass`'s optimistic write).
-  A footswitch-bound plugin is the opposite: `toggle_plugin_bypass` routes through the
+  that path must update local state itself: `Plugin.toggle_bypass` commits, which
+  writes and publishes as one act and reverts if the send never leaves. A
+  footswitch-bound plugin is the opposite: `toggle_plugin_bypass` routes through the
   footswitch press path, which sends MIDI CC → mod-host → feedback echo, and that echo
-  reconciles it. The asymmetry is deliberate, not a bug to "fix."
+  reconciles it. The asymmetry is deliberate, not a bug to "fix." Every bypass — LCD
+  tile, plugin panel button, footswitch — goes through `Handler.toggle_plugin_bypass`.
+
+- **`loading_start` opens a window that suppresses outbound sends; `loading_end`
+  closes it.** Both come from mod-ui, in pairs, from a board load and from the
+  connect dump alike. Nothing else may raise `_is_pedalboard_loading` — a window
+  raised where nothing closes it silently refuses every parameter send for the rest
+  of the session, and `commit` then rolls each edit back on screen.
+  `set_current_pedalboard` clears it as the point we have caught up, which also
+  covers the one case mod-ui abandons its own window (an aborted load returns before
+  `loading_end`).
 
 - **Send form and echo form differ.** We send `param_set /graph/{id}/{sym} {v}`; both broadcast paths come back as `param_set /graph/{id} {sym} {v:%f}`
 

--- a/blend/manager.py
+++ b/blend/manager.py
@@ -101,8 +101,6 @@ class BlendMode:
         if self.config.get("input_id") is None:
             raise ValueError("Blend mode requires 'input_id' config")
 
-        if self.handler.ws_bridge is None:
-            raise RuntimeError("Blend mode requires an active WebSocket bridge")
         assert self.handler.current is not None, "Blend mode requires a loaded pedalboard"
 
         self.parameter_setter = ParameterSetter(self.handler.ws_bridge)
@@ -193,10 +191,9 @@ class BlendMode:
     # ----------------------------------------------------------------- helpers
 
     def _clear_ws_queue(self) -> None:
-        if self.handler.ws_bridge:
-            cleared = self.handler.ws_bridge.clear_queue()
-            if cleared > 0:
-                logging.debug(f"Cleared {cleared} pending WebSocket messages")
+        cleared = self.handler.ws_bridge.clear_queue()
+        if cleared > 0:
+            logging.debug(f"Cleared {cleared} pending WebSocket messages")
 
     def _extract_midi_bound_parameters(self) -> MidiBoundParams:
         """Collect (instance_id, symbol) for every MIDI-bound parameter on the current pedalboard."""

--- a/common/param_source.py
+++ b/common/param_source.py
@@ -15,24 +15,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Reactive param-source protocol — the seam a `PluginPanel` core depends on.
+"""What `PluginPanel` needs of the thing it edits.
 
-`PluginPanel[TState]` was originally hardwired to `modalapi.plugin.Plugin`.
-The Audio & MIDI menu (see `docs/audio-midi-menu.md`) edits synthetic
-parameters — audiocard levels + the 5 global-EQ bands — with no backing
-`Plugin`. Rather than hand-rolling a parallel edit/commit pipeline, the
-behaviour core was lifted off `Plugin` onto this protocol: anything that
-exposes subscribable `Parameter`s and a `set_param_value` write path reuses
-`PluginPanel`'s coalescing queue, the subscribe→dirty→`apply_state`
-reconcile, and `edit_symbol`'s `ParameterSteps` math.
-
-`Plugin` satisfies `ParamSource` structurally with no edits; the audio
-menu's source is a synthetic bundle (see `plugins.audio_midi.source`).
-Bypass/reset are *not* on the protocol — a source without a bypass
-(audiocard, global EQ) composes the reactive core with a footer that
-omits the Bypass/Reset buttons (§4.2 of the doc). The bypass wiring on
-`PluginPanel` guards on `hasattr`-free `isinstance` against the optional
-`BypassSource` extension so a bypass-free core is a valid configuration.
+`Plugin` and the Audio & MIDI synthetic bundle both satisfy it structurally.
+Bypass is not part of it: a source without one gets a footer with no
+Bypass/Reset, and `PluginPanel` gates that wiring on `isinstance(source,
+Plugin)`.
 """
 
 from __future__ import annotations
@@ -46,14 +34,8 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class ParamSource(Protocol):
-    """A reactive bag of parameters a `PluginPanel` core can edit.
+    """Subscribable parameters plus a write path. Satisfied structurally."""
 
-    Structural — `modalapi.plugin.Plugin` and the Audio & MIDI synthetic
-    bundle both satisfy this without inheriting it.
-    """
-
-    # Protocol attributes: a plain instance attribute satisfies these, so
-    # `Plugin.instance_id` / `Plugin.parameters` match without changes.
     instance_id: str
     parameters: "dict[Symbol, Parameter]"
 
@@ -62,24 +44,6 @@ class ParamSource(Protocol):
     def subscribe(self, cb: "Callable[[Parameter], None]") -> "Callable[[], None]": ...
 
 
-@runtime_checkable
-class BypassSource(Protocol):
-    """Optional bypass surface a `ParamSource` may also expose.
-
-    `Plugin` implements this; the Audio & MIDI synthetic bundle does not.
-    `PluginPanel`'s bypass/reset path guards on `isinstance(source,
-    BypassSource)` so a bypass-free source simply has no bypass button.
-    """
-
-    def is_bypassed(self) -> bool: ...
-
-    def set_bypass(self, bypass: bool) -> None: ...
-
-    pedalboard_snapshot: "dict[Symbol, float]"
-
-
 ParamSink = Callable[["Parameter"], bool]
-"""
-The sink for a committed parameter value (e.g. to mod-ui, MIDI out, the audio
-card). Returns False if it didn't send, which tells `commit` to revert the value.
-"""
+"""Carries a committed value upstream (mod-ui, MIDI out, the audio card).
+False means it did not send, and `commit` reverts the value."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,13 +220,29 @@ The outlier is a **non-footswitch UI bypass** (e.g. tapping a plugin on the LCD)
 4. mod-host does NOT generate `param_set` feedback for `bypass` commands it received
    from mod-ui
 
-As such, no echo arrives. In this case, pi-Stomp updates local state and LCD
-immediately, then sends WS to keep mod-ui in sync.
+As such, no echo arrives, and nothing will correct a local write that mod-ui never
+received. So this path commits (`Parameter.commit`): it writes and paints
+immediately, publishes over the WebSocket, and reverts if the send never left the
+box — during a pedalboard load, or under backpressure.
 
 ### Backpressure
 
 `command_queue` is unbounded — never drops blend-mode messages. If the TCP write
-buffer exceeds 8KB, outbound sends return `False` until it drains.
+buffer exceeds 8KB, outbound sends return `False` until it drains. A `False` return
+means the value never left, so a `commit` reverts it rather than showing a value
+mod-ui does not have; a panel's coalescing queue instead keeps it and retries on the
+next tick, since backpressure is transient.
+
+### Outbound suppression during a load
+
+`loading_start` .. `loading_end` brackets mod-ui replaying a whole graph at us — a
+board load, or the connect dump on every WebSocket connect. While it is open,
+inbound graph messages are replay rather than news, and outbound parameter sends are
+refused (`_publish_plugin_param`). `set_current_pedalboard` also clears the flag, as
+the point where we have caught up with the board mod-ui loaded; that covers the one
+case mod-ui abandons its own window, an aborted load returning before `loading_end`.
+Nothing else may raise it: a window that nothing closes refuses every send for the
+rest of the session.
 
 ## Pedalboard Data Loading
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -225,6 +225,18 @@ received. So this path commits (`Parameter.commit`): it writes and paints
 immediately, publishes over the WebSocket, and reverts if the send never left the
 box — during a pedalboard load, or under backpressure.
 
+A footswitch-bound plugin differs only in transport: `_sink_for` finds the bound
+`Footswitch` and publishes the commit as MIDI CC, so mod-host's echo reconciles it.
+Both are one commit on `:bypass`, and the keycap and LED follow from
+`StatefulController`'s settled subscription rather than from having run a press. The
+UI never fakes a press — the row that wins that switch need not be the bypass.
+
+That CC has two codes, so it reaches only the two ends of the binding range (the
+min/max of mod-ui's advanced MIDI-learn menu, which is what a press alternates
+between). `_publish_switch_cc` sends anything between them over the WebSocket
+instead. The choice is made at publish time, not in `_sink_for`, which runs before
+the commit writes the value.
+
 ### Backpressure
 
 `command_queue` is unbounded — never drops blend-mode messages. If the TCP write

--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -754,6 +754,7 @@ class Modhandler(Handler):
         elif isinstance(msg, LoadingEndMessage):
             # Sometimes mod-ui sends us -1 for preset index, but shows 0 anyway ("Default")
             self.next_pedalboard_preset_index = max(0, msg.snapshot_id)
+            self._is_pedalboard_loading = False
 
         elif isinstance(msg, PedalSnapshotMessage):
             if self.next_pedalboard_preset_index is not None:
@@ -965,7 +966,6 @@ class Modhandler(Handler):
 
         # Check for pedalboard change via last.json
         if self.last_json_monitor.check_for_change():
-            self._is_pedalboard_loading = True
             self.lcd.draw_info_message("Loading...")
             mod_bundle = read_pedalboard_bundle(self.last_json_monitor.path)
             if mod_bundle and self._current is not None and mod_bundle != self._current.pedalboard.bundle:
@@ -978,7 +978,6 @@ class Modhandler(Handler):
                     # the bundle we have nothing to load and no business picking
                     # a substitute mid-session. Keep the board we have.
                     logging.warning("last.json names a pedalboard MOD-UI does not list: %s", mod_bundle)
-                    self._is_pedalboard_loading = False
                     self.lcd.link_data(self.pedalboard_list, self.current, self.hardware.footswitches)
                     self.lcd.draw_main_panel()
                     return
@@ -1201,7 +1200,7 @@ class Modhandler(Handler):
             self.blend_modes = {}
             self.active_blend_mode = None
 
-        # Resume outbound WebSocket messages now that the new pedalboard is fully set up.
+        # Caught up with mod-ui. Also closes a window an aborted load left open.
         self._is_pedalboard_loading = False
 
     def bind_current_pedalboard(self):
@@ -1247,7 +1246,7 @@ class Modhandler(Handler):
         return True
 
     def _publish_plugin_param(self, param: Parameter) -> bool:
-        if self._is_pedalboard_loading or self.ws_bridge is None or param.instance_id is None:
+        if self._is_pedalboard_loading or param.instance_id is None:
             return False
         return self.ws_bridge.send_parameter(param.instance_id, param.symbol, param.value)
 
@@ -1402,7 +1401,7 @@ class Modhandler(Handler):
     #
     # Plugin Stuff
     #
-    def toggle_plugin_bypass(self, plugin):
+    def toggle_plugin_bypass(self, plugin: Plugin) -> None:
         logging.debug("toggle_plugin_bypass")
         if plugin is not None:
             if plugin.has_footswitch:
@@ -1410,12 +1409,12 @@ class Modhandler(Handler):
                     if isinstance(c, Footswitch):
                         self._handle_footswitch(c, SwitchEventKind.PRESS, time.monotonic())
                         return
-            # Optimistic: no echo arrives for a WS-initiated bypass, so the local
-            # write is the only thing that repaints (via the bypass subscription).
-            # Contrast with footswitches, which send MIDI CC → mod-host → feedback.
-            value = plugin.toggle_bypass()
-            if not self._is_pedalboard_loading:
-                self.ws_bridge.send_parameter(plugin.instance_id, BYPASS_SYMBOL, value)
+            # No echo arrives for a WS-initiated bypass, so the local write is the
+            # only thing that repaints (via the bypass subscription). Contrast with
+            # footswitches, which send MIDI CC → mod-host → feedback.
+            param = plugin.parameters.get(BYPASS_SYMBOL)
+            if param is not None:
+                plugin.toggle_bypass(self._sink_for(param))
 
     def update_lcd_fs(self, footswitch=None, bypass_change=False):
         self.lcd.update_footswitch(footswitch)
@@ -1860,7 +1859,7 @@ class Modhandler(Handler):
         # Returns whether the value left, so a failed send rolls the LCD back.
         if bpm is None:
             return False
-        if self.ws_bridge is not None and self.ws_bridge.send_bpm(bpm):
+        if self.ws_bridge.send_bpm(bpm):
             return True
         resp = self._rest_post(self.root_uri + "set_bpm", json={"value": bpm})
         return resp is not None and resp.ok

--- a/modalapi/modhandler.py
+++ b/modalapi/modhandler.py
@@ -105,7 +105,6 @@ from pistomp.controller import ControlType
 from modalapi.version_check import DpkgDriftCheck
 
 from pistomp.controller_manager import ControllerManager
-from pistomp.controller import Controller
 from pistomp.current import Current
 from pistomp.encoder_controller import (
     ENCODER_FALLBACK_DEFAULT,
@@ -414,7 +413,7 @@ class Modhandler(Handler):
             # One transport per bound turn: the sink (CC to mod-host for a mapped
             # encoder, the WebSocket for :bpm) owns the send.
             new_value = ParameterSteps.for_parameter(c.parameter).move(delta)
-            c.parameter.commit(new_value, self._sink_for(c.parameter, c))
+            c.parameter.commit(new_value, self._sink_for(c.parameter))
             self.lcd.display_parameter_value(c.parameter, new_value)
             return True
 
@@ -1209,26 +1208,24 @@ class Modhandler(Handler):
         # any real time settings
         self._controller_manager.bind(self.current)
 
-    def _sink_for(self, param: Parameter, controller: Controller | None = None) -> ParamSink | None:
-        """The upstream channel a param's commit rides, by provenance. None is
-        display-only: reconciled from mod-ui, never sent back — bpb/rolling when
-        unmapped (mod-ui rejects param_set on them) and an external footswitch
-        (its press path owns the CC). A param mapped to an encoder rides that
-        encoder's CC; :bpm is the exception — its range won't fit 7 bits, so it
-        keeps the WebSocket. Pass *controller* when the caller holds it (an
-        encoder turn); otherwise it's recovered from the binding."""
+    def _sink_for(self, param: Parameter) -> ParamSink | None:
+        """Where a changed value is sent. None means send nothing: the screen
+        shows the value, and only mod-ui changes it — bpb/rolling when unmapped
+        (mod-ui rejects param_set on them) and an external control, whose own
+        port owns the CC. Both bail below the encoder arm and above the
+        footswitch one, so a bound encoder still rides its CC and an external
+        footswitch does not."""
         if param.instance_id == Pedalboard.TRANSPORT_INSTANCE_ID and param.symbol == BPM_SYMBOL:
             return self._publish_bpm
         if param.instance_id is None:
             return self._publish_audio
-        enc = controller if isinstance(controller, EncoderController) else None
-        if enc is None and param.binding is not None:
-            enc = self.hardware.controllers.get(param.binding)
-            enc = enc if isinstance(enc, EncoderController) else None
-        if enc is not None and enc.midi_CC is not None:
-            return functools.partial(self._publish_cc, enc)
+        control = self._current.control_for(param) if self._current is not None else None
+        if isinstance(control, EncoderController) and control.midi_CC is not None:
+            return functools.partial(self._publish_cc, control)
         if param.instance_id in (ExternalMidi.EXTERNAL_INSTANCE_ID, Pedalboard.TRANSPORT_INSTANCE_ID):
             return None
+        if isinstance(control, Footswitch) and control.midi_CC is not None:
+            return functools.partial(self._publish_switch_cc, control)
         return self._publish_plugin_param
 
     def _publish_bpm(self, param: Parameter) -> bool:
@@ -1243,6 +1240,17 @@ class Modhandler(Handler):
     def _publish_cc(self, controller: EncoderController, param: Parameter) -> bool:
         """Publish the parameter (to MOD-UI or anything else) via MIDI CC."""
         self._emit_midi(controller, controller.to_midi(param.value))
+        return True
+
+    def _publish_switch_cc(self, fs: Footswitch, param: Parameter) -> bool:
+        """A switch's CC has two codes, so it carries only the two ends of the
+        binding range. An edit that lands between them takes the WebSocket, or
+        mod-host would answer the screen with an endpoint. Decided here, not in
+        _sink_for, which runs before the commit writes the value."""
+        cc = fs.cc_for(param.value)
+        if cc is None:
+            return self._publish_plugin_param(param)
+        self._emit_midi(fs, cc)
         return True
 
     def _publish_plugin_param(self, param: Parameter) -> bool:
@@ -1403,18 +1411,9 @@ class Modhandler(Handler):
     #
     def toggle_plugin_bypass(self, plugin: Plugin) -> None:
         logging.debug("toggle_plugin_bypass")
-        if plugin is not None:
-            if plugin.has_footswitch:
-                for c in plugin.controllers:
-                    if isinstance(c, Footswitch):
-                        self._handle_footswitch(c, SwitchEventKind.PRESS, time.monotonic())
-                        return
-            # No echo arrives for a WS-initiated bypass, so the local write is the
-            # only thing that repaints (via the bypass subscription). Contrast with
-            # footswitches, which send MIDI CC → mod-host → feedback.
-            param = plugin.parameters.get(BYPASS_SYMBOL)
-            if param is not None:
-                plugin.toggle_bypass(self._sink_for(param))
+        param = plugin.parameters.get(BYPASS_SYMBOL)
+        if param is not None:
+            plugin.toggle_bypass(self._sink_for(param))
 
     def update_lcd_fs(self, footswitch=None, bypass_change=False):
         self.lcd.update_footswitch(footswitch)

--- a/modalapi/plugin.py
+++ b/modalapi/plugin.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 from common.color import RectBorder
 from common.parameter import BYPASS_SYMBOL, Parameter, Symbol, json_default
+from common.param_source import ParamSink
 from modalapi.plugin_customization import PluginCustomization, PluginExtraData
 from pistomp.controller import Controller
 
@@ -126,13 +127,11 @@ class Plugin:
             return bool(param.value)
         return True
 
-    def toggle_bypass(self) -> float:
+    def toggle_bypass(self, sink: ParamSink | None) -> None:
+        """Flip bypass and publish it as one act."""
         param = self.parameters.get(BYPASS_SYMBOL)
-        if param is None:
-            return 0.0
-        new_value = 0.0 if param.value else 1.0
-        param.preview(new_value)
-        return new_value
+        if param is not None:
+            param.commit(0.0 if param.value else 1.0, sink)
 
     def set_param_value(self, symbol: Symbol, value: float) -> None:
         """Reconcile a param to mod-ui's value. Any bound stateful controller
@@ -149,9 +148,11 @@ class Plugin:
         """Fan *cb* out over every parameter. Returns a single unsubscriber that
         tears down all per-param subscriptions, so a panel subscribes once."""
         unsubs = [p.subscribe(cb) for p in self.parameters.values()]
+
         def _unsub() -> None:
             for u in unsubs:
                 u()
+
         return _unsub
 
     def to_json(self) -> str:

--- a/modalapi/plugin.py
+++ b/modalapi/plugin.py
@@ -62,7 +62,6 @@ class Plugin:
         self.bypass_indicator_xy: tuple[Point, Point] = ((0, 0), (0, 0))
         self.lcd_xyz: LcdPosition | None = None
         self.controllers: list[Controller] = []
-        self.has_footswitch: bool = False
         self.category: str | None = category
         self.uri: str | None = uri
         self.pedalboard_snapshot: dict[Symbol, float] = {}

--- a/pistomp/controller_manager.py
+++ b/pistomp/controller_manager.py
@@ -126,7 +126,6 @@ class ControllerManager:
                 current.track_plugin_binding(plugin, controller)
 
                 if isinstance(controller, Footswitch):
-                    plugin.has_footswitch = True
                     controller.set_category(plugin.category)
                     event_kind = EventKind.PRESS
                     cls = ControlClass.FOOTSWITCH

--- a/pistomp/current.py
+++ b/pistomp/current.py
@@ -40,14 +40,30 @@ class Current:
     analog_controllers: AnalogControllers = field(default_factory=dict)
     _controllers: list[Controller] = field(default_factory=list)
     _plugin_bindings: list[tuple[Plugin, Controller]] = field(default_factory=list)
+    _control_by_param: dict[Parameter, Controller] = field(default_factory=dict)
 
     def bind(self, controller: Controller, parameter: Parameter) -> None:
+        self._release(controller)
         controller.bind_to_parameter(parameter)
+        self._control_by_param[parameter] = controller
         self.track(controller)
 
     def attach(self, controller: Controller, parameter: Parameter) -> None:
+        self._release(controller)
         controller.parameter = parameter
+        self._control_by_param[parameter] = controller
         self.track(controller)
+
+    def control_for(self, parameter: Parameter) -> Controller | None:
+        """The control bound to this parameter. A CC number is an address, not
+        an identity: two parameters can name the same one, so the binder's
+        decision is the record and this is how to read it."""
+        return self._control_by_param.get(parameter)
+
+    def _release(self, controller: Controller) -> None:
+        prior = controller.parameter
+        if prior is not None and self._control_by_param.get(prior) is controller:
+            del self._control_by_param[prior]
 
     def track(self, controller: Controller) -> None:
         if controller not in self._controllers:
@@ -63,9 +79,9 @@ class Current:
         for plugin, controller in reversed(self._plugin_bindings):
             if controller in plugin.controllers:
                 plugin.controllers.remove(controller)
-            plugin.has_footswitch = any(isinstance(c, Footswitch) for c in plugin.controllers)
         for controller in reversed(self._controllers):
             controller.unbind_from_parameter()
         self._plugin_bindings.clear()
         self._controllers.clear()
+        self._control_by_param.clear()
         self.analog_controllers = {}

--- a/pistomp/current.py
+++ b/pistomp/current.py
@@ -24,7 +24,6 @@ from common.parameter import Parameter
 from modalapi.pedalboard import Pedalboard
 from modalapi.plugin import Plugin
 from pistomp.controller import AnalogControllers, Controller
-from pistomp.footswitch import Footswitch
 
 
 @dataclass

--- a/pistomp/footswitch.py
+++ b/pistomp/footswitch.py
@@ -134,28 +134,45 @@ class Footswitch(controller.StatefulController):
         indicators itself. When bound to a plugin :bypass, the WS broadcast does."""
         return self.parameter is None
 
+    @property
+    def _toggle_extents(self) -> tuple[float, float] | None:
+        """The (off, on) values this switch alternates between. None for
+        :bypass and unbound, whose polarity is inverted."""
+        param = self.parameter
+        if param is None or param.symbol == BYPASS_SYMBOL:
+            return None
+        lo = param.minimum if param.minimum is not None else 0
+        hi = param.maximum if param.maximum is not None else 1
+        return lo, hi
+
+    def is_on(self, value: float) -> bool:
+        extents = self._toggle_extents
+        if extents is None:
+            return value < 1
+        lo, hi = extents
+        return value >= (lo + hi) / 2
+
     @override
     def set_value(self, value: float):
-        param = self.parameter
-        if param is not None and param.symbol != BYPASS_SYMBOL:
-            # Non-:bypass binding: "on" is the max end, so compare against midpoint.
-            lo = param.minimum if param.minimum is not None else 0
-            hi = param.maximum if param.maximum is not None else 1
-            self.toggled = value >= (lo + hi) / 2
-        else:
-            self.toggled = value < 1
+        self.toggled = self.is_on(value)
         self.set_led(self.toggled)
         self.refresh_callback(footswitch=self)
 
+    def cc_for(self, value: float) -> int | None:
+        """This switch's CC code for *value*, or None where it has none: it
+        reaches the two ends of the binding range and nothing between them."""
+        if value == self.value_for(True):
+            return 127
+        if value == self.value_for(False):
+            return 0
+        return None
+
     def value_for(self, toggled: bool) -> float:
-        """Parameter value for a toggle state — the inverse of set_value's read.
-        Non-:bypass: "on" is the max end. :bypass: "on" is not-bypassed, i.e. 0."""
-        param = self.parameter
-        if param is not None and param.symbol != BYPASS_SYMBOL:
-            lo = param.minimum if param.minimum is not None else 0
-            hi = param.maximum if param.maximum is not None else 1
-            return hi if toggled else lo
-        return 0 if toggled else 1
+        extents = self._toggle_extents
+        if extents is None:
+            return 0 if toggled else 1
+        lo, hi = extents
+        return hi if toggled else lo
 
     def current_toggle_state(self) -> bool:
         return self.toggled

--- a/pistomp/handler.py
+++ b/pistomp/handler.py
@@ -105,6 +105,12 @@ class Handler(InputSink):
         per-parameter dialog as open_parameter_dialog."""
         raise NotImplementedError()
 
+    def toggle_plugin_bypass(self, plugin: "Plugin") -> None:
+        """Flip a plugin's bypass the one way the whole UI flips it: through the
+        footswitch press path when the plugin has one (so mod-host's echo
+        reconciles it), else committed over the WebSocket."""
+        raise NotImplementedError()
+
     def open_audio_parameter_dialog(
         self, parameter: "Parameter", commit_callback: Callable[[str, float], None]
     ) -> None:

--- a/plugins/audio_midi/panel.py
+++ b/plugins/audio_midi/panel.py
@@ -566,8 +566,8 @@ class AudioMidiPanel(ModalDialog[AudioMidiState]):
 
     # ── no mod-host echo to send; the synthetic source already wrote the card ──
 
-    def _send_param(self, instance_id: str, symbol: Symbol, value: float) -> None:
-        pass
+    def _send_param(self, instance_id: str, symbol: Symbol, value: float) -> bool:
+        return True  # the card is already written; nothing to mirror
 
     # ── selection ─────────────────────────────────────────────────────────────
 

--- a/plugins/audio_midi/source.py
+++ b/plugins/audio_midi/source.py
@@ -15,25 +15,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pi-stomp.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Synthetic reactive param source for the Audio & MIDI menu.
+"""Synthetic `ParamSource` for the Audio & MIDI menu.
 
-The Audio & MIDI menu edits the audiocard's global EQ (5 bands) and
-input/output levels — there is no backing ``Plugin``. Per
-``docs/audio-midi-menu.md`` §4.1 these are modelled as synthetic reactive
-``Parameter``s so the menu reuses ``PluginPanel``'s entire param machinery
-(coalescing, subscribe→dirty→apply_state, edit_symbol's ParameterSteps math)
-instead of bespoke commit callbacks.
-
-The source satisfies ``common.param_source.ParamSource`` structurally:
-``parameters``, ``instance_id``, ``set_param_value`` (the write side —
-commits to the audiocard), ``subscribe`` (fans out over the synthetic
-parameters). It does **not** implement ``BypassSource`` — the audio menu
-has no bypass, so the reactive core's bypass/reset paths no-op and the
-footer omits Bypass/Reset (§4.2).
-
-Symbols are the audiocard's ALSA mixer names (``MASTER``, ``CAPTURE_VOLUME``,
-``EQ_1``..``EQ_5``), so the existing ``audio_parameter_commit`` write path
-matches exactly.
+The audiocard's levels and global EQ have no backing `Plugin`, so they are
+modelled as reactive `Parameter`s and the menu reuses `PluginPanel` whole.
+Symbols are the ALSA mixer names (`MASTER`, `CAPTURE_VOLUME`, `EQ_1`..`EQ_5`),
+which is what `audio_parameter_commit` writes. Not a `Plugin`: no bypass.
 """
 
 from __future__ import annotations
@@ -48,9 +35,8 @@ if TYPE_CHECKING:
     from pistomp.audiocard import Audiocard
     from pistomp.hardware import Hardware
 
-# instance_id for the synthetic source. ``_flush_param_queue`` keys the
-# WebSocket send on this; ``_send_param`` is overridden to no-op (no
-# mod-host instance), so the value is purely diagnostic.
+# No mod-host instance to send to (`_send_param` is overridden), so this is
+# diagnostic only.
 INSTANCE_ID = "audio_midi"
 
 # Range mirror of modhandler._create_audio_parameter / bind_volume_encoder.

--- a/plugins/base.py
+++ b/plugins/base.py
@@ -59,7 +59,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 
 from common.contexts import ControlClass, ControlRef, EventKind
 from common.param_roles import ParamRole
-from common.param_source import BypassSource, ParamSource
+from common.param_source import ParamSource
 from common.parameter import BYPASS_SYMBOL, Parameter, Symbol
 from common.parameter_steps import ParameterSteps, effective_multiplier
 from modalapi.plugin import Plugin
@@ -93,9 +93,9 @@ class PluginPanel(Panel, Generic[TState], ABC):
     structurally; the Audio & MIDI menu supplies a synthetic bundle of the
     audiocard + global-EQ params (see ``docs/audio-midi-menu.md`` §4.1).
 
-    Bypass/reset are gated on the source also implementing
-    ``BypassSource``; a bypass-free source (audiocard, global EQ) simply
-    composes this core with a footer that omits Bypass/Reset.
+    Bypass/reset are gated on the source being a ``Plugin``; a bypass-free
+    source (audiocard, global EQ) simply composes this core with a footer
+    that omits Bypass/Reset.
 
     Inherits ``Panel`` (so subclasses get the widget/selection API) but never
     calls ``Panel.__init__`` itself — the concrete child picks the actual panel
@@ -289,38 +289,35 @@ class PluginPanel(Panel, Generic[TState], ABC):
         if not self._param_queue:
             return
         instance_id = self.plugin.instance_id
-        for symbol, value in self._param_queue.items():
-            self._send_param(instance_id, symbol, value)
-        self._param_queue.clear()
+        for symbol, value in list(self._param_queue.items()):
+            # A send that did not leave (backpressure) stays queued: the value is
+            # not wrong, it is late, and a newer one for the same symbol replaces
+            # it next tick — same coalescing the queue already does.
+            if self._send_param(instance_id, symbol, value):
+                del self._param_queue[symbol]
 
-    def _send_param(self, instance_id: str, symbol: Symbol, value: float) -> None:
-        """Commit one queued param to the backend. Plugin panels send over the
-        WebSocket; a synthetic source (audiocard) overrides to no-op — its
-        ``set_param_value`` already wrote the hardware and there is no
-        mod-host instance to mirror."""
-        bridge = self.handler.ws_bridge
-        if bridge is not None:
-            bridge.send_parameter(instance_id, symbol, value)
+    def _send_param(self, instance_id: str, symbol: Symbol, value: float) -> bool:
+        """Commit one queued param to the backend, returning whether it left.
+        Plugin panels send over the WebSocket; a synthetic source (audiocard)
+        overrides — its ``set_param_value`` already wrote the hardware and there
+        is no mod-host instance to mirror."""
+        return self.handler.ws_bridge.send_parameter(instance_id, symbol, value)
 
     # ── chrome actions ─────────────────────────────────────────────────────
 
     def _on_toggle_bypass(self) -> None:
         source = self.plugin
-        if not isinstance(source, BypassSource) or self._btn_bypass is None:
+        if not isinstance(source, Plugin) or self._btn_bypass is None:
             return
-        new_bypass = not source.is_bypassed()
-        source.set_bypass(new_bypass)
-        bridge = self.handler.ws_bridge
-        if bridge is not None:
-            bridge.send_parameter(source.instance_id, BYPASS_SYMBOL, 1.0 if new_bypass else 0.0)
-        # Optimistic: the set_bypass above already marked us dirty, so tick would
-        # repaint within 10ms anyway. Painting here keeps the button instant.
+        self.handler.toggle_plugin_bypass(source)
+        # The flip already marked us dirty, so tick would repaint within 10ms
+        # anyway. Painting here keeps the button instant.
         self._refresh_bypass_style()
 
     def _on_reset(self) -> None:
         """Restore all symbols from the parse-time snapshot, skipping locked ones and :bypass."""
         source = self.plugin
-        if not isinstance(source, BypassSource):
+        if not isinstance(source, Plugin):
             return
         self._flush_param_queue()
         snap = source.pedalboard_snapshot
@@ -341,7 +338,7 @@ class PluginPanel(Panel, Generic[TState], ABC):
         if self._btn_bypass is None:
             return
         source = self.plugin
-        bypassed = source.is_bypassed() if isinstance(source, BypassSource) else False
+        bypassed = source.is_bypassed() if isinstance(source, Plugin) else False
         self._btn_bypass.set_background(BYPASS_ACTIVE_COLOR if bypassed else (0, 0, 0))
         self._btn_bypass.refresh()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,7 +269,7 @@ def make_plugin():
     from modalapi.parameter import Parameter
     from plugins.customization import lookup
 
-    def _make(instance_id, category="Distortion", bypassed=False, has_footswitch=False, parameters=None, uri=None):
+    def _make(instance_id, category="Distortion", bypassed=False, parameters=None, uri=None):
         if parameters is None:
             parameters = {}
         bypass_info: PortInfo = {"shortName": "bypass", "symbol": ":bypass", "ranges": {"minimum": 0, "maximum": 1}}
@@ -278,7 +278,6 @@ def make_plugin():
         # Fixture acts as the composition root: resolve customization by URI,
         # mirroring how the handler injects it in production.
         p = Plugin(instance_id, parameters, {}, category, uri=uri, customization=lookup(uri))
-        p.has_footswitch = has_footswitch
         return p
 
     return _make

--- a/tests/pedalboard_fixtures.py
+++ b/tests/pedalboard_fixtures.py
@@ -7,7 +7,7 @@ one of the topologies here.
 
 Each helper returns a `MockPedalboard` exposing the duck-typed attributes
 used by `lcd320x240.draw_plugins`: `title`, `plugins` (with `instance_id`,
-`is_bypassed()`, `category`, `has_footswitch`, `controllers`), and
+`is_bypassed()`, `category`, `controllers`), and
 `connections` (a list of `modalapi.connections.Connection`).
 """
 
@@ -25,7 +25,6 @@ from modalapi.plugin_customization import PluginExtraData
 class MockPlugin:
     instance_id: str
     category: str = "Distortion"
-    has_footswitch: bool = False
     bypassed: bool = False
     controllers: list = field(default_factory=list)
     uri: str | None = None
@@ -120,10 +119,10 @@ def blank() -> MockPedalboard:
 def linear_chain() -> MockPedalboard:
     """Classic serial chain: distort → delay → reverb → chorus."""
     plugins = [
-        MockPlugin("distortion", "Distortion", has_footswitch=True),
-        MockPlugin("delay", "Delay", has_footswitch=True),
-        MockPlugin("reverb", "Reverb", has_footswitch=True, bypassed=True),
-        MockPlugin("chorus", "Modulator", has_footswitch=False),
+        MockPlugin("distortion", "Distortion"),
+        MockPlugin("delay", "Delay"),
+        MockPlugin("reverb", "Reverb", bypassed=True),
+        MockPlugin("chorus", "Modulator"),
     ]
     return MockPedalboard(
         title="Rock Rig",
@@ -167,15 +166,15 @@ def tall_parallel() -> MockPedalboard:
     Lane 5 (depth 1): Chorus ────────────────(dummies)─────────┘
     """
     plugins = [
-        MockPlugin("gate", "Dynamics", has_footswitch=True),
-        MockPlugin("amp", "Amplifier", has_footswitch=True),
+        MockPlugin("gate", "Dynamics"),
+        MockPlugin("amp", "Amplifier"),
         MockPlugin("cab", "Utility"),
-        MockPlugin("comp", "Dynamics", has_footswitch=True),
-        MockPlugin("drive", "Distortion", has_footswitch=True),
+        MockPlugin("comp", "Dynamics"),
+        MockPlugin("drive", "Distortion"),
         MockPlugin("eq", "EQ"),
-        MockPlugin("delay", "Delay", has_footswitch=True),
-        MockPlugin("reverb", "Reverb", has_footswitch=True),
-        MockPlugin("chorus", "Modulator", has_footswitch=True),
+        MockPlugin("delay", "Delay"),
+        MockPlugin("reverb", "Reverb"),
+        MockPlugin("chorus", "Modulator"),
         MockPlugin("x42-eq", "EQ"),
     ]
     conns = [
@@ -212,8 +211,8 @@ def stereo_chain() -> MockPedalboard:
     capture_2 → EQ(1) → Comp(1) → Limit(1) → playback_2
     """
     plugins = [
-        MockPlugin("eq", "EQ", has_footswitch=True),
-        MockPlugin("comp", "Dynamics", has_footswitch=True),
+        MockPlugin("eq", "EQ"),
+        MockPlugin("comp", "Dynamics"),
         MockPlugin("limit", "Dynamics"),
     ]
     conns = [
@@ -241,8 +240,8 @@ def split_merge() -> MockPedalboard:
     """
     plugins = [
         MockPlugin("split", "Utility"),
-        MockPlugin("delay", "Delay", has_footswitch=True),
-        MockPlugin("reverb", "Reverb", has_footswitch=True),
+        MockPlugin("delay", "Delay"),
+        MockPlugin("reverb", "Reverb"),
         MockPlugin("merge", "Utility"),
     ]
     conns = [
@@ -269,20 +268,20 @@ def parallel_beths() -> MockPedalboard:
                 ├── OD → Chorus           ──┤→ MixEQ → playback_{1,2}
                 └── Gate                  ──┘
     """
-    # (instance_id, category, has_footswitch, bypassed)
-    _LANES: list[list[tuple[str, str, bool, bool]]] = [
+    # (instance_id, category, bypassed)
+    _LANES: list[list[tuple[str, str, bool]]] = [
         # Lane A – Clean (depth 3)
-        [("Comp", "Dynamics", True, False), ("Amp", "Amplifier", True, False), ("Delay", "Delay", True, False)],
+        [("Comp", "Dynamics", False), ("Amp", "Amplifier", False), ("Delay", "Delay", False)],
         # Lane B – Crunch (depth 2; Chorus bypassed)
-        [("OD", "Distortion", True, False), ("Chorus", "Modulator", True, True)],
+        [("OD", "Distortion", False), ("Chorus", "Modulator", True)],
         # Lane C – Gate only (depth 1)
-        [("Gate", "Dynamics", False, False)],
+        [("Gate", "Dynamics", False)],
     ]
 
     lane_plugins: list[list[MockPlugin]] = [
-        [MockPlugin(iid, cat, fs, byp) for iid, cat, fs, byp in lane] for lane in _LANES
+        [MockPlugin(iid, cat, byp) for iid, cat, byp in lane] for lane in _LANES
     ]
-    mix_eq = MockPlugin("MixEQ", "EQ", False, False)
+    mix_eq = MockPlugin("MixEQ", "EQ", False)
     all_plugins: list[MockPlugin] = [p for lane in lane_plugins for p in lane] + [mix_eq]
     assert len(all_plugins) == 7, f"expected 7, got {len(all_plugins)}"
 

--- a/tests/test_controller_manager.py
+++ b/tests/test_controller_manager.py
@@ -142,3 +142,21 @@ def test_encoder_longpress_builds_callback_effect_row():
     effects = [e for e in rows[0].effects if isinstance(e, CallbackEffect)]
     assert len(effects) == 1
     assert effects[0].name == "next_snapshot"
+
+
+def test_one_control_on_two_params_answers_for_the_last_only():
+    """Two plugin parameters can name one CC. The address does not say which of
+    them the control ended up on, so Current records the binder's decision and
+    the loser must not still resolve to that control."""
+    info: PortInfo = {"shortName": "Gain", "symbol": "gain", "ranges": {"minimum": 0.0, "maximum": 1.0}}
+    first = Parameter(info, 0.5, "13:60", "amp")
+    second = Parameter(info, 0.5, "13:60", "drive")
+    knob = _external_analog()
+    current = _make_current()
+
+    current.bind(cast(Controller, knob), first)
+    current.bind(cast(Controller, knob), second)
+
+    assert current.control_for(second) is knob
+    assert current.control_for(first) is None
+    assert knob.parameter is second

--- a/tests/test_lcd320x240.py
+++ b/tests/test_lcd320x240.py
@@ -41,7 +41,6 @@ def _make_plugin(
     instance_id: str,
     uri: str | None = None,
     category: str | None = None,
-    has_footswitch: bool = False,
     bypassed: bool = False,
     parameters: dict[Symbol, Parameter] | None = None,
 ) -> Plugin:
@@ -49,7 +48,6 @@ def _make_plugin(
     all_params: dict[Symbol, Parameter] = dict(parameters or {})
     all_params[BYPASS_SYMBOL] = Parameter(bypass_info, 1.0 if bypassed else 0.0, None, instance_id)
     plugin = Plugin(instance_id, all_params, {}, category, uri=uri)
-    plugin.has_footswitch = has_footswitch
     return plugin
 
 
@@ -140,25 +138,22 @@ def setup_main_ui(instance):
             "distortion",
             uri="mock://distortion",
             category="Distortion",
-            has_footswitch=True,
             parameters={Symbol("gain"): mock_gain},
         ),
         _make_plugin(
             "delay",
             uri="mock://delay",
             category="Delay",
-            has_footswitch=True,
             parameters={Symbol("time"): mock_time},
         ),
         _make_plugin(
             "reverb",
             uri="mock://reverb",
             category="Reverb",
-            has_footswitch=True,
             bypassed=True,
             parameters={Symbol("mix"): mock_mix},
         ),
-        _make_plugin("chorus", uri="mock://chorus", category="Modulator", has_footswitch=False),
+        _make_plugin("chorus", uri="mock://chorus", category="Modulator"),
     ]
     ids = [p.instance_id for p in plugins]
     connections = [

--- a/tests/test_plugin_panels.py
+++ b/tests/test_plugin_panels.py
@@ -21,8 +21,11 @@ from common.parameter import BYPASS_SYMBOL, Symbol
 class FakeWsBridge:
     def __init__(self):
         self.sent: list[tuple[str, str, float]] = []
+        self.refusing = False  # stands in for backpressure
 
     def send_parameter(self, instance_id: str, symbol: str, value: float) -> bool:
+        if self.refusing:
+            return False
         self.sent.append((instance_id, symbol, value))
         return True
 
@@ -34,6 +37,12 @@ class FakeHandler:
 
     def is_symbol_locked(self, instance_id: str, symbol: str) -> bool:
         return (instance_id, symbol) in self.locked
+
+    def toggle_plugin_bypass(self, plugin) -> None:
+        """Mirrors Modhandler for a footswitch-less plugin: commit over the WS."""
+        plugin.toggle_bypass(
+            lambda param: self.ws_bridge.send_parameter(plugin.instance_id, BYPASS_SYMBOL, param.value)
+        )
 
 
 # ── minimal concrete panel ───────────────────────────────────────────────────
@@ -129,6 +138,34 @@ class TestPluginPanel:
         panel.tick()
         assert panel._param_queue == {}
         assert fake_handler.ws_bridge.sent == [("pedalboard/demo", "gain", 7.0)]
+
+    def test_refused_send_stays_queued_and_retries(self, fake_plugin, fake_handler):
+        """Backpressure is transient: the value is late, not wrong. It waits in
+        the queue instead of being dropped on the floor."""
+        panel = DemoPanel(plugin=fake_plugin, handler=fake_handler, on_dismiss=lambda: None)
+        fake_handler.ws_bridge.refusing = True
+        panel.set_param(Symbol("gain"), 7.0)
+        panel.tick()
+        assert panel._param_queue == {Symbol("gain"): 7.0}
+        assert fake_handler.ws_bridge.sent == []
+
+        fake_handler.ws_bridge.refusing = False
+        panel.tick()
+        assert panel._param_queue == {}
+        assert fake_handler.ws_bridge.sent == [("pedalboard/demo", "gain", 7.0)]
+
+    def test_refused_send_is_superseded_by_a_newer_value(self, fake_plugin, fake_handler):
+        """A spin that keeps moving replaces the waiting value; only the latest
+        is sent, which is the coalescing the queue already promises."""
+        panel = DemoPanel(plugin=fake_plugin, handler=fake_handler, on_dismiss=lambda: None)
+        fake_handler.ws_bridge.refusing = True
+        panel.set_param(Symbol("gain"), 7.0)
+        panel.tick()
+
+        panel.set_param(Symbol("gain"), 8.0)
+        fake_handler.ws_bridge.refusing = False
+        panel.tick()
+        assert fake_handler.ws_bridge.sent == [("pedalboard/demo", "gain", 8.0)]
 
     def test_handle_encoder_returns_true_when_consumed(self, fake_plugin, fake_handler):
         panel = DemoPanel(plugin=fake_plugin, handler=fake_handler, on_dismiss=lambda: None)

--- a/tests/v3/test_acomp_panel.py
+++ b/tests/v3/test_acomp_panel.py
@@ -45,7 +45,6 @@ def make_acomp_plugin(instance_id: str = "Comp") -> Plugin:
         Symbol("mak"): _param(Symbol("mak"), 6.0, 0.0, 30.0, instance_id),
     }
     plugin = Plugin(instance_id, params, {}, "Dynamics", uri=ACOMP_URI, customization=lookup(ACOMP_URI))
-    plugin.has_footswitch = True
     plugin.pedalboard_snapshot = {
         sym: float(p.value) if p.value is not None else 0.0 for sym, p in params.items()
     }

--- a/tests/v3/test_caps_noisegate_menu.py
+++ b/tests/v3/test_caps_noisegate_menu.py
@@ -67,7 +67,6 @@ def make_noisegate_plugin(instance_id: str = "Gate") -> Plugin:
         Symbol("mains"): _param(Symbol("mains"), 50.0, 0.0, 100.0, instance_id, unit="Hz"),
     }
     plugin = Plugin(instance_id, params, {}, "Dynamics", uri=CAPS_NOISEGATE_URI, customization=lookup(CAPS_NOISEGATE_URI))
-    plugin.has_footswitch = True
     plugin.pedalboard_snapshot = {
         sym: float(p.value) if p.value is not None else 0.0
         for sym, p in params.items()
@@ -177,7 +176,6 @@ def test_parameter_window_scrolls_when_content_overflows(v3_system: SystemFixtur
         sym = Symbol(f"param_{i:02d}")
         params[sym] = _param(sym, 0.5, 0.0, 1.0, "many", unit="dB")
     plugin = Plugin("many", params, {}, "Dynamics")
-    plugin.has_footswitch = True
     plugin.pedalboard_snapshot = {sym: 0.5 for sym in params}
 
     handler.current.pedalboard.plugins = [plugin]

--- a/tests/v3/test_encoder_dispatch.py
+++ b/tests/v3/test_encoder_dispatch.py
@@ -159,7 +159,7 @@ def test_parameter_dialog_nav_change_emits_cc_for_external_param(v3_system: Syst
 
     enc1 = _enc(hw, 1)
     ext_param = hw.create_external_parameter("virtual", enc1.midi_channel, enc1.midi_CC)
-    enc1.bind_to_parameter(ext_param)
+    handler.current.bind(enc1, ext_param)
     binding = f"{enc1.midi_channel}:{enc1.midi_CC}"
     hw.controllers[binding] = enc1
     handler._controller_manager.effective_table = ContextStack(
@@ -221,7 +221,7 @@ def test_tweak_bound_to_different_param_does_not_corrupt_it(v3_system: SystemFix
     enc1 = _enc(hw, 1)
     # Param B: the pedalboard-bound param tweak1 normally drives.
     bound_param = hw.create_external_parameter("virtual", enc1.midi_channel, enc1.midi_CC)
-    enc1.bind_to_parameter(bound_param)
+    handler.current.bind(enc1, bound_param)
     binding = f"{enc1.midi_channel}:{enc1.midi_CC}"
     hw.controllers[binding] = enc1
     handler._controller_manager.effective_table = ContextStack(
@@ -310,7 +310,7 @@ def test_tweak_bound_to_same_param_as_dialog_edits_once(v3_system: SystemFixture
 
     enc1 = _enc(hw, 1)
     ext_param = hw.create_external_parameter("virtual", enc1.midi_channel, enc1.midi_CC)
-    enc1.bind_to_parameter(ext_param)
+    handler.current.bind(enc1, ext_param)
     binding = f"{enc1.midi_channel}:{enc1.midi_CC}"
     hw.controllers[binding] = enc1
     handler._controller_manager.effective_table = ContextStack(

--- a/tests/v3/test_eq_panel.py
+++ b/tests/v3/test_eq_panel.py
@@ -81,7 +81,6 @@ def make_fil4_plugin(instance_id: str = "fil4") -> Plugin:
             params[b.gain_sym] = _param(b.gain_sym, 0.0, -18.0, 18.0, instance_id=instance_id, unit="dB")
 
     plugin = Plugin(instance_id, params, {}, "Filter", uri=FIL4_MONO_URI)
-    plugin.has_footswitch = False
     # Simulate parse-time snapshot for Reset
     plugin.pedalboard_snapshot = {
         sym: float(p.value) if p.value is not None else 0.0

--- a/tests/v3/test_eq_units.py
+++ b/tests/v3/test_eq_units.py
@@ -52,7 +52,6 @@ def _finish(instance_id: str, params: dict[Symbol, Parameter], uri: str) -> Plug
     bypass: PortInfo = {"shortName": "bypass", "symbol": ":bypass", "ranges": {"minimum": 0, "maximum": 1}}
     params[BYPASS_SYMBOL] = Parameter(bypass, False, None, instance_id)
     plugin = Plugin(instance_id, params, {}, "Filter", uri=uri)
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {s: float(p.value or 0.0) for s, p in params.items()}
     return plugin
 

--- a/tests/v3/test_footswitch_order.py
+++ b/tests/v3/test_footswitch_order.py
@@ -39,7 +39,7 @@ def test_footswitch_order_stable_across_reload(v3_system, nav_handler, make_plug
         # A plugin whose :bypass is bound to the footswitch in `slot`. binding is
         # the "<channel>:<cc>" key that bind_current_pedalboard resolves to the
         # hardware footswitch controller.
-        p = make_plugin(instance_id, category=category, has_footswitch=True)
+        p = make_plugin(instance_id, category=category)
         p.parameters[BYPASS_SYMBOL].binding = f"{ch}:{SLOT_CC[slot]}"
         return p
 

--- a/tests/v3/test_footswitch_param_sync.py
+++ b/tests/v3/test_footswitch_param_sync.py
@@ -37,7 +37,7 @@ def _bind_solo_footswitch(v3_system: SystemFixture, make_plugin, make_parameter)
     fs0 = hw.footswitches[0]
     binding = f"{ch}:{fs0.midi_CC}"
 
-    plugin = make_plugin("mixer", has_footswitch=True)
+    plugin = make_plugin("mixer")
     solo = make_parameter("Solo1", "mixer", value=0.0, minimum=0.0, maximum=1.0)
     solo.binding = binding
     plugin.parameters[solo.symbol] = solo

--- a/tests/v3/test_footswitch_table_dispatch.py
+++ b/tests/v3/test_footswitch_table_dispatch.py
@@ -7,6 +7,8 @@ action type — preset, taptempo, midi_CC toggle, relay longpress, plugin-:bypas
 hardware side effects.
 """
 
+from unittest.mock import Mock
+
 from common.contexts import (
     ControlClass,
     EventKind,
@@ -106,7 +108,7 @@ def test_plugin_bound_footswitch_has_param_effect_row(v3_system: SystemFixture, 
     fs0 = v3_system.hw.footswitches[0]
     binding = f"{ch}:{fs0.midi_CC}"
 
-    plugin = make_plugin("fuzz", has_footswitch=True)
+    plugin = make_plugin("fuzz")
     plugin.parameters[BYPASS_SYMBOL].binding = binding
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
@@ -124,18 +126,17 @@ def test_plugin_bound_footswitch_has_param_effect_row(v3_system: SystemFixture, 
     assert len(cc_effects) == 0
 
 
-def test_toggle_plugin_bypass_through_table_fires_param_effect(v3_system: SystemFixture, make_plugin):
-    """toggle_plugin_bypass() on a footswitch-bound plugin routes through the
-    Modhandler._handle_footswitch override → table → ParamEffect arm. With a
-    properly built table (bind_current_pedalboard after setting the binding),
-    the winner is the ParamEffect row, not a stale MidiCcEffect toggle row."""
+def test_ui_bypass_of_a_bound_plugin_does_not_fire_the_table_row(v3_system: SystemFixture, make_plugin):
+    """The binder gives a bypass-bound switch a ParamEffect row, not a stale
+    MidiCcEffect toggle row. A UI bypass must not fire it: the row that wins
+    that switch need not be the bypass, so the button commits instead."""
     handler = v3_system.handler
     hw = v3_system.hw
     ch = hw.midi_channel
     fs0 = hw.footswitches[0]
     binding = f"{ch}:{fs0.midi_CC}"
 
-    plugin = make_plugin("fuzz", has_footswitch=True)
+    plugin = make_plugin("fuzz")
     plugin.parameters[BYPASS_SYMBOL].binding = binding
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
@@ -147,12 +148,11 @@ def test_toggle_plugin_bypass_through_table_fires_param_effect(v3_system: System
     param_rows = [r for r in rows if r.control.id == binding and any(isinstance(e, ParamEffect) for e in r.effects)]
     assert len(param_rows) == 1
 
-    hw.midiout.send_message.reset_mock()
+    handler._handle_footswitch = Mock()
     handler.toggle_plugin_bypass(plugin)
 
-    hw.midiout.send_message.assert_called_once()
-    sent_cc = hw.midiout.send_message.call_args[0][0]
-    assert sent_cc[1] == fs0.midi_CC
+    handler._handle_footswitch.assert_not_called()
+    assert plugin.is_bypassed() is True
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +255,7 @@ def test_taptempo_footswitch_with_plugin_binding_stamps_when_enabled(v3_system: 
     binding = f"{ch}:{fs3.midi_CC}"
 
     # Bind fs3 to a plugin :bypass
-    plugin = make_plugin("fuzz", has_footswitch=True)
+    plugin = make_plugin("fuzz")
     plugin.parameters[BYPASS_SYMBOL].binding = binding
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
@@ -287,7 +287,7 @@ def test_taptempo_footswitch_with_plugin_binding_toggles_bypass_when_disabled(v3
     assert not fs3.taptempo.is_enabled()  # disabled by default
     binding = f"{ch}:{fs3.midi_CC}"
 
-    plugin = make_plugin("fuzz", has_footswitch=True)
+    plugin = make_plugin("fuzz")
     plugin.parameters[BYPASS_SYMBOL].binding = binding
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()

--- a/tests/v3/test_graphic_eq_panel.py
+++ b/tests/v3/test_graphic_eq_panel.py
@@ -60,7 +60,6 @@ def make_capseq10_plugin(instance_id: str = "eq10") -> Plugin:
         params[b.gain_sym] = _param(b.gain_sym, 0.0, b.gain_min, b.gain_max, instance_id=instance_id, unit="dB")
 
     plugin = Plugin(instance_id, params, {}, "EQ", uri=CAPSEQ10_URI)
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {
         sym: float(p.value) if p.value is not None else 0.0
         for sym, p in params.items()

--- a/tests/v3/test_gx_cabinet_panel.py
+++ b/tests/v3/test_gx_cabinet_panel.py
@@ -91,7 +91,6 @@ def make_gx_cabinet_plugin(instance_id: str = "cabinet") -> Plugin:
         Symbol("c_model"): _param(Symbol("c_model"), 0.0, 0.0, 18.0, 0.0, instance_id, enum_values=_MODEL_SCALEPOINTS),
     }
     plugin = Plugin(instance_id, params, {}, "GxCabinet", uri=GX_CABINET_URI)
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {sym: float(p.value) if p.value is not None else 0.0 for sym, p in params.items()}
     return plugin
 

--- a/tests/v3/test_midi_learn.py
+++ b/tests/v3/test_midi_learn.py
@@ -31,7 +31,7 @@ def test_v3_midi_learn_binds_footswitch_live(v3_system: SystemFixture, make_plug
     fs0 = hw.footswitches[0]
     channel, cc = _binding_for(hw, fs0).split(":")
 
-    plugin = make_plugin("noise", category="Utility", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", category="Utility", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -41,7 +41,7 @@ def test_v3_midi_learn_binds_footswitch_live(v3_system: SystemFixture, make_plug
     handler.poll_ws_messages()
 
     assert fs0.parameter is plugin.parameters[BYPASS_SYMBOL]
-    assert plugin.has_footswitch is True
+    assert fs0 in plugin.controllers
     snapshot("bound")
 
 
@@ -57,7 +57,7 @@ def test_v3_midi_learn_replay_is_idempotent(v3_system: SystemFixture, make_plugi
     fs0 = hw.footswitches[0]
     channel, cc = _binding_for(hw, fs0).split(":")
 
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -83,7 +83,7 @@ def test_v3_param_set_syncs_bound_footswitch(v3_system: SystemFixture, make_plug
     channel, cc = _binding_for(hw, fs0).split(":")
 
     solo = make_parameter("Solo", "mixer", value=0.0)
-    plugin = make_plugin("mixer", bypassed=False, has_footswitch=False, parameters={"solo": solo})
+    plugin = make_plugin("mixer", bypassed=False, parameters={"solo": solo})
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -113,7 +113,7 @@ def test_v3_midi_learn_applies_custom_sub_range(v3_system: SystemFixture, make_p
 
     gain = make_parameter("Gain", "noise", value=0.25)
     assert (gain.minimum, gain.maximum) == (0.0, 1.0)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.0 0.5")
@@ -138,7 +138,7 @@ def test_v3_midi_learn_sub_range_saga(v3_system: SystemFixture, make_plugin, mak
     channel, cc = _binding_for(hw, enc1).split(":")
 
     gain = make_parameter("Gain", "noise", value=0.15)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -180,7 +180,7 @@ def test_v3_log_parameter_dialog_paints_geometric_curve(v3_system: SystemFixture
     assert handler.current and handler.lcd
 
     freq = Parameter(LOG_PORT, 155.0, None, "eq")  # geometric midpoint: half the bars fill
-    plugin = make_plugin("eq", bypassed=False, has_footswitch=False, parameters={"hpfreq": freq})
+    plugin = make_plugin("eq", bypassed=False, parameters={"hpfreq": freq})
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -204,7 +204,7 @@ def test_v3_midi_learn_logarithmic_cc_round_trips(v3_system: SystemFixture, make
     channel, cc = _binding_for(hw, enc1).split(":")
 
     freq = Parameter(LOG_PORT, 400.0, None, "eq")
-    plugin = make_plugin("eq", bypassed=False, has_footswitch=False, parameters={"hpfreq": freq})
+    plugin = make_plugin("eq", bypassed=False, parameters={"hpfreq": freq})
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -237,7 +237,7 @@ def test_v3_log_parameter_commit_emits_tapered_cc(v3_system: SystemFixture, make
     channel, cc = _binding_for(hw, enc1).split(":")
 
     freq = Parameter(LOG_PORT, 30.0, None, "eq")
-    plugin = make_plugin("eq", bypassed=False, has_footswitch=False, parameters={"hpfreq": freq})
+    plugin = make_plugin("eq", bypassed=False, parameters={"hpfreq": freq})
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
 
@@ -274,7 +274,7 @@ def test_v3_midi_learn_external_controller_is_refused(v3_system: SystemFixture, 
     parameter_before = enc1.parameter
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.0 1.0")
@@ -298,14 +298,14 @@ def test_v3_midi_learn_unknown_instance_is_ignored(v3_system: SystemFixture, mak
     fs0 = hw.footswitches[0]
     channel, cc = _binding_for(hw, fs0).split(":")
 
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/other :bypass {channel} {cc} 0.0 1.0")
     handler.poll_ws_messages()
 
     assert fs0.parameter is None
-    assert plugin.has_footswitch is False
+    assert fs0 not in plugin.controllers
 
 
 def test_v3_midi_learn_adds_table_row_for_encoder(v3_system: SystemFixture, make_plugin, make_parameter):
@@ -322,7 +322,7 @@ def test_v3_midi_learn_adds_table_row_for_encoder(v3_system: SystemFixture, make
     channel, cc = _binding_for(hw, enc1).split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.0 1.0")
@@ -351,7 +351,7 @@ def test_v3_midi_learn_reroutes_an_already_bound_pedalboard(v3_system: SystemFix
     channel, cc = _binding_for(hw, enc1).split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
 
@@ -385,7 +385,7 @@ def test_v3_midi_unlearn_encoder_clears_binding_and_updates_lcd(
     channel, cc = binding_id.split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -414,7 +414,8 @@ def test_v3_midi_unlearn_encoder_clears_binding_and_updates_lcd(
 
 
 def test_v3_midi_unlearn_footswitch_clears_binding(v3_system: SystemFixture, make_plugin, snapshot):
-    """Removing a footswitch MIDI mapping in MOD-UI clears footswitch state and has_footswitch flag."""
+    """Removing a footswitch MIDI mapping in MOD-UI clears the footswitch state
+    and detaches it from the plugin."""
     handler = v3_system.handler
     hw = v3_system.hw
     ws_bridge = v3_system.ws_bridge
@@ -425,7 +426,7 @@ def test_v3_midi_unlearn_footswitch_clears_binding(v3_system: SystemFixture, mak
     binding_id = _binding_for(hw, fs0)
     channel, cc = binding_id.split(":")
 
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -433,7 +434,7 @@ def test_v3_midi_unlearn_footswitch_clears_binding(v3_system: SystemFixture, mak
     ws_bridge.inject(f"midi_map /graph/noise :bypass {channel} {cc} 0.0 1.0")
     handler.poll_ws_messages()
     assert fs0.parameter is plugin.parameters[BYPASS_SYMBOL]
-    assert plugin.has_footswitch is True
+    assert fs0 in plugin.controllers
     snapshot("bound")
 
     # Unmap in MOD-UI
@@ -442,7 +443,7 @@ def test_v3_midi_unlearn_footswitch_clears_binding(v3_system: SystemFixture, mak
     assert fs0.parameter is None
     assert fs0.display_label is None
     assert fs0.category is None
-    assert plugin.has_footswitch is False
+    assert fs0 not in plugin.controllers
     snapshot("unbound")
 
 
@@ -470,7 +471,7 @@ def test_v3_midi_unlearn_restores_footswitch_default_action(v3_system: SystemFix
         rows = handler.effective_table.layers[0].rows.get((ControlClass.FOOTSWITCH, EventKind.PRESS), [])
         return [r for r in rows if r.control.id == binding_id]
 
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -512,7 +513,7 @@ def test_v3_midi_learn_updated_binding_range_on_same_parameter(v3_system: System
     channel, cc = _binding_for(hw, enc1).split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     # Initial mapping: sub-range 0.0 .. 0.5
@@ -547,7 +548,7 @@ def test_v3_midi_unlearn_restores_declared_range(v3_system: SystemFixture, make_
     channel, cc = _binding_for(hw, enc1).split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.1 0.9")
@@ -580,7 +581,7 @@ def test_v3_midi_learn_free_cc_preserves_sub_range(v3_system: SystemFixture, mak
     channel, cc = binding.split(":")
 
     gain = make_parameter("Gain", "noise", value=0.5)
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False, parameters={"gain": gain})
+    plugin = make_plugin("noise", bypassed=False, parameters={"gain": gain})
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject(f"midi_map /graph/noise gain {channel} {cc} 0.0 0.5")
@@ -608,7 +609,7 @@ def test_v3_midi_learn_moving_footswitch_binding_clears_old_lcd_display(v3_syste
     ch0, cc0 = _binding_for(hw, fs0).split(":")
     ch1, cc1 = _binding_for(hw, fs1).split(":")
 
-    plugin = make_plugin("noise", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("noise", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     lcd.draw_main_panel()
@@ -630,7 +631,6 @@ def test_v3_midi_learn_moving_footswitch_binding_clears_old_lcd_display(v3_syste
     assert fs0.parameter is None
     assert fs0.display_label is None
     assert fs0.category is None
-    assert plugin.has_footswitch is True
     assert plugin.controllers.count(fs0) == 0
     assert plugin.controllers.count(fs1) == 1
 

--- a/tests/v3/test_mixer_panel.py
+++ b/tests/v3/test_mixer_panel.py
@@ -46,7 +46,6 @@ def make_mixer_plugin(instance_id: str = "mixer") -> Plugin:
     params[Symbol("MasterVolume")] = _param("MasterVolume", 0.75, 0.0, 1.0, 0.75, instance_id)
     params[Symbol("AltVolume")] = _param("AltVolume", 0.5, 0.0, 1.0, 0.5, instance_id)
     plugin = Plugin(instance_id, params, {}, "Mixer", uri=MOD_MIXER_URI)
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {sym: float(p.value) if p.value is not None else 0.0
                                   for sym, p in params.items()}
     return plugin

--- a/tests/v3/test_notes_panel.py
+++ b/tests/v3/test_notes_panel.py
@@ -70,7 +70,6 @@ def make_notes_plugin(instance_id: str = "notes_1") -> Plugin:
         customization=lookup(NOTES_URI),
         extra_data=NotesData(text=_NOTES_TEXT),
     )
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {BYPASS_SYMBOL: 0.0}
     return plugin
 

--- a/tests/v3/test_param_dialog_suppression.py
+++ b/tests/v3/test_param_dialog_suppression.py
@@ -1,7 +1,6 @@
-"""A NAV edit in the parameter dialog is the one path that goes through
-``Parameter.commit``, which rolls back when the send does not leave. Outbound
-suppression that outlives its load therefore reads on the LCD as a dialog that
-opens but will not move."""
+"""Outbound suppression that outlives its load reads on the LCD as a parameter
+dialog that opens but will not move: ``Parameter.commit`` rolls back when the
+send does not leave."""
 
 from __future__ import annotations
 

--- a/tests/v3/test_param_dialog_suppression.py
+++ b/tests/v3/test_param_dialog_suppression.py
@@ -1,0 +1,65 @@
+"""A NAV edit in the parameter dialog is the one path that goes through
+``Parameter.commit``, which rolls back when the send does not leave. Outbound
+suppression that outlives its load therefore reads on the LCD as a dialog that
+opens but will not move."""
+
+from __future__ import annotations
+
+from modalapi.parameter import Parameter
+from modalapi.plugin import Plugin
+from common.parameter import BYPASS_SYMBOL, Symbol
+from uilib.misc import InputEvent
+from uilib.parameterdialog import Parameterdialog
+from tests.types import SystemFixture
+from tests.v3.nav_helpers import nav_click, nav_step
+from tests.v3.test_caps_noisegate_menu import _param
+
+
+def _open_dialog(v3_system: SystemFixture) -> Plugin:
+    handler = v3_system.handler
+    hw = v3_system.hw
+    assert handler.current
+
+    params: dict[Symbol, Parameter] = {
+        BYPASS_SYMBOL: Parameter(
+            {"shortName": "bypass", "symbol": ":bypass", "ranges": {"minimum": 0, "maximum": 1}}, False, None, "many"
+        ),
+    }
+    for i in range(6):
+        sym = Symbol(f"param_{i:02d}")
+        params[sym] = _param(sym, 0.5, 0.0, 1.0, "many", unit="dB")
+    plugin = Plugin("many", params, {}, "Dynamics")
+    plugin.pedalboard_snapshot = {sym: 0.5 for sym in params}
+
+    handler.current.pedalboard.plugins = [plugin]
+    handler.current.pedalboard.connections = []
+    handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
+    handler.lcd.draw_main_panel()
+
+    lcd = handler.lcd
+    lcd.main_panel.sel_widget(lcd.w_plugins[0])
+    lcd.main_panel.input_event(InputEvent.LONG_CLICK)
+    handler.poll_lcd_updates()
+
+    nav_click(handler)
+    handler.poll_lcd_updates()
+    assert isinstance(lcd.pstack.current, Parameterdialog)
+    return plugin
+
+
+def test_nav_edits_dialog_after_bundleless_load(v3_system: SystemFixture):
+    """A load that names no new bundle must not leave outbound sends
+    suppressed: NAV in the dialog still edits the parameter."""
+    handler = v3_system.handler
+
+    v3_system.ws_bridge.inject("loading_start 0")
+    v3_system.ws_bridge.inject("loading_end 1")
+    handler.poll_ws_messages()
+
+    plugin = _open_dialog(v3_system)
+    for _ in range(8):
+        nav_step(handler, 1)
+    handler.poll_lcd_updates()
+
+    assert plugin.parameters[Symbol("param_00")].value > 0.5
+    assert v3_system.ws_bridge.sent_values_for(plugin.instance_id, "param_00")

--- a/tests/v3/test_pedalboards.py
+++ b/tests/v3/test_pedalboards.py
@@ -227,8 +227,9 @@ def test_v3_loading_start_suppresses_outbound_ws(v3_system: SystemFixture):
 
 
 def test_v3_same_bundle_last_json_clears_suppression(v3_system: SystemFixture):
-    """Save in MOD-UI rewrites last.json under the bundle already current, and
-    emits no loading_start/loading_end pair at all (mod-ui host.py save_pedalboard).
+    """last.json can name the bundle that is already current: mod-ui writes it
+    during its own start, and again on a save. Neither is a load, and the save
+    emits no loading_start/loading_end pair (mod-ui host.py save_pedalboard).
     Nothing is loading, so nothing may suppress outbound sends."""
     handler = v3_system.handler
     assert handler.current

--- a/tests/v3/test_pedalboards.py
+++ b/tests/v3/test_pedalboards.py
@@ -185,7 +185,9 @@ def test_v3_refetch_drops_boards_modui_no_longer_lists(v3_system: SystemFixture)
 
 
 def test_v3_outbound_ws_suppressed_during_pedalboard_change(v3_system: SystemFixture, make_plugin):
-    """While a pedalboard change is in flight, outbound param_set messages are dropped."""
+    """While a pedalboard change is in flight, outbound param_set messages are
+    dropped — and the LCD does not show a bypass mod-ui never received. No echo
+    comes back for a WS bypass, so a local flip here would stand uncorrected."""
     handler = v3_system.handler
     ws_bridge = v3_system.ws_bridge
 
@@ -201,15 +203,16 @@ def test_v3_outbound_ws_suppressed_during_pedalboard_change(v3_system: SystemFix
     handler._is_pedalboard_loading = True
     handler.toggle_plugin_bypass(old_plugin)
 
-    # The bypass should flip locally, but NO ws message should be sent
-    assert old_plugin.is_bypassed()
+    # Nothing sent, and nothing shown: the commit rolls back to the last
+    # value mod-ui confirmed.
+    assert not old_plugin.is_bypassed()
     assert ws_bridge.sent_values_for("old_fuzz", ":bypass") == []
 
-    # After clearing suppression, sends resume
+    # After clearing suppression, the same tap both sends and shows
     handler._is_pedalboard_loading = False
     handler.toggle_plugin_bypass(old_plugin)
-    assert not old_plugin.is_bypassed()
-    assert ws_bridge.sent_values_for("old_fuzz", ":bypass") == [0.0]
+    assert old_plugin.is_bypassed()
+    assert ws_bridge.sent_values_for("old_fuzz", ":bypass") == [1.0]
 
 
 def test_v3_loading_start_suppresses_outbound_ws(v3_system: SystemFixture):
@@ -221,6 +224,33 @@ def test_v3_loading_start_suppresses_outbound_ws(v3_system: SystemFixture):
     ws_bridge.inject("loading_start 0")
     handler.poll_ws_messages()
     assert handler._is_pedalboard_loading is True
+
+
+def test_v3_same_bundle_last_json_clears_suppression(v3_system: SystemFixture):
+    """Save in MOD-UI rewrites last.json under the bundle already current, and
+    emits no loading_start/loading_end pair at all (mod-ui host.py save_pedalboard).
+    Nothing is loading, so nothing may suppress outbound sends."""
+    handler = v3_system.handler
+    assert handler.current
+
+    last_json = Path(handler.data_dir) / "last.json"
+    last_json.write_text(json.dumps({"pedalboard": handler.current.pedalboard.bundle}))
+    os.utime(last_json, (9999, 9999))
+
+    handler.poll_modui_changes()
+    assert handler._is_pedalboard_loading is False
+
+
+def test_v3_loading_end_clears_suppression(v3_system: SystemFixture):
+    """loading_end closes the window loading_start opened. A load that names no
+    new bundle never reaches set_current_pedalboard, so nothing else would."""
+    handler = v3_system.handler
+    ws_bridge = v3_system.ws_bridge
+
+    ws_bridge.inject("loading_start 0")
+    ws_bridge.inject("loading_end 1")
+    handler.poll_ws_messages()
+    assert handler._is_pedalboard_loading is False
 
 
 def test_v3_set_current_pedalboard_clears_suppression(v3_system: SystemFixture, make_plugin):

--- a/tests/v3/test_plugins.py
+++ b/tests/v3/test_plugins.py
@@ -47,8 +47,7 @@ def test_v3_bind_footswitch_to_plugin(v3_system: SystemFixture, make_plugin):
     handler.bind_current_pedalboard()
 
     assert fs0.parameter is plugin.parameters[BYPASS_SYMBOL]
-    assert plugin.has_footswitch is True
-    assert plugin in [p for p in handler.current.pedalboard.plugins if p.has_footswitch]
+    assert fs0 in plugin.controllers
 
 
 def test_v3_bind_encoder_midi_to_plugin(v3_system: SystemFixture, make_plugin):
@@ -106,7 +105,7 @@ def test_v3_bind_does_not_reorder_footswitch_plugins(v3_system: SystemFixture, m
     handler.bind_current_pedalboard()
 
     assert hw.controllers[fs_key].parameter is fuzz.parameters[BYPASS_SYMBOL]
-    assert fuzz.has_footswitch is True
+    assert hw.controllers[fs_key] in fuzz.controllers
     titles = [p.instance_id for p in handler.current.pedalboard.plugins]
     assert titles == ["fuzz", "reverb"], "v3 must not reorder footswitch plugins"
 
@@ -156,7 +155,7 @@ def test_v3_toggle_plugin_bypass_no_footswitch_sends_websocket(v3_system: System
     assert handler.current
     assert handler.lcd
 
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -193,7 +192,6 @@ def test_v3_nam_plugin_uses_tri_color_tile(v3_system: SystemFixture, make_plugin
         "nam_amp",
         category="Simulator",
         bypassed=False,
-        has_footswitch=False,
         uri=nam_uri,
     )
     handler.current.pedalboard.plugins = [plugin]
@@ -220,10 +218,10 @@ def test_v3_nam_plugin_mixed_with_other_types(v3_system: SystemFixture, make_plu
 
     nam_uri = NAM_URIS[0]
     plugins = [
-        make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False),
-        make_plugin("nam1", category="Simulator", bypassed=False, has_footswitch=False, uri=nam_uri),
-        make_plugin("delay", category="Delay", bypassed=False, has_footswitch=False),
-        make_plugin("nam2", category="Simulator", bypassed=True, has_footswitch=False, uri=nam_uri),
+        make_plugin("fuzz", category="Distortion", bypassed=False),
+        make_plugin("nam1", category="Simulator", bypassed=False, uri=nam_uri),
+        make_plugin("delay", category="Delay", bypassed=False),
+        make_plugin("nam2", category="Simulator", bypassed=True, uri=nam_uri),
     ]
     handler.current.pedalboard.plugins = plugins
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
@@ -241,8 +239,8 @@ def test_v3_nam_plugin_mixed_with_other_types(v3_system: SystemFixture, make_plu
 
 
 def test_v3_toggle_plugin_bypass_via_footswitch(v3_system: SystemFixture, make_plugin, get_urls):
-    """Plugin with has_footswitch: toggle_plugin_bypass() sends MIDI and waits
-    for the WS echo to update state and display."""
+    """A plugin whose :bypass is on a footswitch: toggle_plugin_bypass() leaves as
+    MIDI CC and waits for the WS echo to update state and display."""
     handler = v3_system.handler
     hw = v3_system.hw
     ws_bridge = v3_system.ws_bridge
@@ -415,7 +413,7 @@ def test_v3_poll_ws_messages_drains_without_file_watch(v3_system: SystemFixture,
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject("param_set /graph/fuzz :bypass 1.0")
@@ -431,7 +429,7 @@ def test_v3_add_dump_reseeds_bypass_on_reconnect(v3_system: SystemFixture, make_
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
 
     ws_bridge.inject("add fuzz http://uri 0.0 0.0 1 1 1")
@@ -448,7 +446,7 @@ def test_v3_add_dynamic_unknown_plugin_empty_info_silently_fails(v3_system: Syst
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    plugin = make_plugin("fuzz", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     before = len(handler.current.pedalboard.plugins)
 
@@ -467,7 +465,7 @@ def test_v3_handle_bypass_event_updates_plugin(v3_system: SystemFixture, make_pl
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -486,7 +484,7 @@ def test_v3_bypass_echo_is_idempotent(v3_system: SystemFixture, make_plugin, sna
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=False)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
     handler.lcd.draw_main_panel()
@@ -543,8 +541,8 @@ def test_v3_snapshot_sequence_applies_bypass_via_ws(v3_system: SystemFixture, ma
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    drive = make_plugin("drive", category="Distortion", bypassed=False, has_footswitch=False)
-    delay = make_plugin("delay", category="Delay", bypassed=False, has_footswitch=False)
+    drive = make_plugin("drive", category="Distortion", bypassed=False)
+    delay = make_plugin("delay", category="Delay", bypassed=False)
     handler.current.pedalboard.plugins = [drive, delay]
     handler.current.pedalboard.connections = [
         Connection(
@@ -585,8 +583,8 @@ def test_v3_reconnect_dump_reseeds_bypass_via_poll(v3_system: SystemFixture, mak
     ws_bridge = v3_system.ws_bridge
 
     assert handler.current
-    drive = make_plugin("drive", category="Distortion", bypassed=False, has_footswitch=False)
-    delay = make_plugin("delay", category="Delay", bypassed=False, has_footswitch=False)
+    drive = make_plugin("drive", category="Distortion", bypassed=False)
+    delay = make_plugin("delay", category="Delay", bypassed=False)
     handler.current.pedalboard.plugins = [drive, delay]
     handler.current.pedalboard.connections = [
         Connection(
@@ -766,8 +764,8 @@ def test_v3_footswitch_states_snapshot(v3_system: SystemFixture, make_plugin, sn
     assert handler.current
     assert handler.lcd
 
-    on_plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=True)
-    off_plugin = make_plugin("delay", category="Delay", bypassed=True, has_footswitch=True)
+    on_plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
+    off_plugin = make_plugin("delay", category="Delay", bypassed=True)
 
     fs0 = hw.footswitches[0]
     fs1 = hw.footswitches[1]

--- a/tests/v3/test_sink_routing.py
+++ b/tests/v3/test_sink_routing.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+
+from common.parameter import Parameter, PortInfo, Symbol
+from pistomp.controller import RoutingInfo
+from pistomp.input.event import SwitchEvent, SwitchEventKind
+from rtmidi.midiconstants import CONTROL_CHANGE
+
+
+def _plugin_with_bound_param(handler, make_plugin, binding: str):
+    info: PortInfo = {"shortName": "Gain", "symbol": "gain", "ranges": {"minimum": 0.0, "maximum": 1.0}}
+    param = Parameter(info, 0.5, binding, "/Amp")
+    plugin = make_plugin("/Amp", parameters={Symbol("gain"): param})
+    pb = handler.pedalboards["/path/to/rig.pedalboard"]
+    pb.plugins = [plugin]
+    handler.set_current_pedalboard(pb)
+    return plugin, param
+
+
+@pytest.mark.parametrize("kind", ["footswitch", "encoder"])
+def test_external_control_never_carries_a_plugin_param(v3_system, make_plugin, kind):
+    """An external control keeps its own CC, so the binder refuses the plugin
+    binding. The sink must refuse it too, or the commit leaves by the external
+    port instead of the WebSocket."""
+    handler = v3_system.handler
+    hw = v3_system.hw
+    pool = hw.footswitches if kind == "footswitch" else hw.encoders
+    control = next(c for c in pool if c.midi_CC is not None)
+    binding = f"{control.midi_channel}:{control.midi_CC}"
+    _, param = _plugin_with_bound_param(handler, make_plugin, binding)
+
+    # The load reinits hardware, clearing routing. Route after it, as a board
+    # declaring midi_port on this control would.
+    hw.external_routing[control] = RoutingInfo.external("My MIDI Device")
+    handler.bind_current_pedalboard()
+
+    assert hw.controllers[binding] is control
+    assert control.parameter is not param
+    assert handler._sink_for(param) == handler._publish_plugin_param
+
+
+def test_param_bound_to_encoder_leaves_as_midi_cc(v3_system, make_plugin):
+    """A turn on a bound knob goes out as MIDI CC, not over the WebSocket."""
+    handler, hw = v3_system.handler, v3_system.hw
+    enc = next(e for e in hw.encoders if e.midi_CC is not None and e.parameter is None)
+    _, param = _plugin_with_bound_param(handler, make_plugin, f"{enc.midi_channel}:{enc.midi_CC}")
+
+    assert enc.parameter is param
+    handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)
+    handler.lcd.draw_main_panel()
+    hw.midiout.send_message.reset_mock()
+
+    enc.refresh(1)
+
+    sent = hw.midiout.send_message.call_args[0][0]
+    assert sent[0] == enc.midi_channel | CONTROL_CHANGE
+    assert sent[1] == enc.midi_CC
+
+
+def _learn_footswitch_to_gain(v3_system, make_plugin, make_parameter, binding_range):
+    """mod-ui's "advanced" MIDI-learn menu: a footswitch CC on a continuous
+    param, with the user's own min/max as the two ends it toggles between."""
+    handler, hw = v3_system.handler, v3_system.hw
+    fs = hw.footswitches[0]
+    gain = make_parameter("Gain", "amp", value=binding_range[0], minimum=0.0, maximum=10.0)
+    gain.binding = f"{hw.midi_channel}:{fs.midi_CC}"
+    plugin = make_plugin("amp")
+    plugin.parameters[gain.symbol] = gain
+    handler.current.pedalboard.plugins = [plugin]
+    gain.set_binding_range(binding_range)
+    handler.bind_current_pedalboard()
+    return handler, hw, fs, gain
+
+
+def test_footswitch_press_toggles_between_the_advanced_endpoints(
+    v3_system, make_plugin, make_parameter
+):
+    handler, hw, fs, gain = _learn_footswitch_to_gain(v3_system, make_plugin, make_parameter, (2.0, 8.0))
+
+    handler.handle(SwitchEvent(controller=fs, kind=SwitchEventKind.PRESS, timestamp=1.0))
+    assert gain.value == 8.0
+    assert hw.midiout.send_message.call_args[0][0][2] == 127
+
+    handler.handle(SwitchEvent(controller=fs, kind=SwitchEventKind.PRESS, timestamp=2.0))
+    assert gain.value == 2.0
+    assert hw.midiout.send_message.call_args[0][0][2] == 0
+
+
+def test_ui_edit_between_the_endpoints_takes_the_websocket(
+    v3_system, make_plugin, make_parameter
+):
+    """The switch's CC has only two codes. A mid-range edit sent that way comes
+    back from mod-host as an endpoint, against a screen showing the real value."""
+    handler, hw, fs, gain = _learn_footswitch_to_gain(v3_system, make_plugin, make_parameter, (2.0, 8.0))
+    hw.midiout.send_message.reset_mock()
+
+    handler.parameter_value_commit(gain, 5.0)
+
+    hw.midiout.send_message.assert_not_called()
+    assert v3_system.ws_bridge.sent_values_for("amp", gain.symbol) == [5.0]
+
+
+def test_ui_edit_landing_on_an_endpoint_rides_the_cc(v3_system, make_plugin, make_parameter):
+    handler, hw, fs, gain = _learn_footswitch_to_gain(v3_system, make_plugin, make_parameter, (2.0, 8.0))
+    hw.midiout.send_message.reset_mock()
+
+    handler.parameter_value_commit(gain, 8.0)
+
+    assert hw.midiout.send_message.call_args[0][0][2] == 127
+    assert v3_system.ws_bridge.sent_values_for("amp", gain.symbol) == []

--- a/tests/v3/test_tap_reverb_panel.py
+++ b/tests/v3/test_tap_reverb_panel.py
@@ -120,7 +120,6 @@ def make_tap_reverb_plugin(instance_id: str = "reverb") -> Plugin:
         Symbol("mode"): _param(Symbol("mode"), 0.0, 0.0, 42.0, 0.0, instance_id, enum_values=_MODE_SCALEPOINTS),
     }
     plugin = Plugin(instance_id, params, {}, "Reverb", uri=TAP_REVERB_URI)
-    plugin.has_footswitch = False
     plugin.pedalboard_snapshot = {sym: float(p.value) if p.value is not None else 0.0 for sym, p in params.items()}
     return plugin
 

--- a/tests/v3/test_tap_tempo_snapshot.py
+++ b/tests/v3/test_tap_tempo_snapshot.py
@@ -7,7 +7,7 @@ def test_v3_tap_tempo_lcd_snapshot(v3_system: SystemFixture, make_plugin, snapsh
     handler = v3_system.handler
     hw = v3_system.hw
 
-    plugin = make_plugin("fuzz", category="Distortion", bypassed=False, has_footswitch=True)
+    plugin = make_plugin("fuzz", category="Distortion", bypassed=False)
     handler.current.pedalboard.plugins = [plugin]
     handler.bind_current_pedalboard()
     handler.lcd.link_data(handler.pedalboard_list, handler.current, hw.footswitches)

--- a/tests/v3/test_transport_bindings.py
+++ b/tests/v3/test_transport_bindings.py
@@ -231,7 +231,7 @@ def test_midi_learn_rolling_labels_footswitch(v3_system: SystemFixture, make_plu
     rolling = tp.parameters[ROLLING_SYMBOL]
     assert rolling.binding == f"{channel}:{cc}"
     assert fs0.parameter is rolling
-    assert tp.has_footswitch is True
+    assert fs0 in tp.controllers
     snapshot("rolling_bound")
 
 


### PR DESCRIPTION
> Written mostly by Claude Code

Sometimes when users turned on their pi-Stomp, longpress worked to open a plugin's controls, but values refused to change. Other times, everything worked as expected. Knobs and encoders bound to plugin parameters continued to work just fine.

### Cause 1 — the suppression window stayed open

poll_modui_changes opened _is_pedalboard_loading at each change of last.json. Only a change of bundle closed it again, through set_current_pedalboard. If last.json named the bundle that was already current, no branch closed the window. _publish_plugin_param then refused all sends, and commit put the last confirmed value back on the screen.

At start this is a race. FileChangeMonitor records the mtime of last.json when Modhandler is constructed. MOD-UI then writes last.json during its own start, with the same bundle. If that write comes after the baseline, the first poll sees a change of the same bundle, and the window stays open. A save in MOD-UI does the same.

**Correction.** Only loading_start opens the window, and loading_end closes it. set_current_pedalboard also closes it, for a load that MOD-UI stopped before loading_end.

### Cause 2 — two dispatch paths for one bypass

The panel bypass button wrote the local value and sent its own WebSocket message, so a bound footswitch did not follow it. toggle_plugin_bypass held a second fork: for a plugin with a footswitch, it made a false press. The binding table then fired the row that won that switch, and that row is not always the bypass.

**Correction.** Each bypass from the UI is one commit on the :bypass parameter. _sink_for selects the transport — the MIDI CC of the bound footswitch, or the WebSocket. The keycap follows, because StatefulController subscribes to the settled value. The UI never makes a false press.

### Cause 3 — a lost edit under "back-pressure"

_flush_param_queue ignored the result of the send and emptied the queue, so the LCD kept a value that MOD-UI did not have. Backpressure (too many items in the send queue) makes a value late, not incorrect. A refused send now stays in the queue and goes again at the next tick, and a newer value for the same symbol replaces it.

I propose that we remove the back-pressure algorithm completely, and instead invest in logging that will tell us if   MOD is not able to keep up with our messages (unlikely outside of blend mode).   

### A defect that we made, and found, in this work

The first correction to cause 2 sent each footswitch-bound parameter out as MIDI CC. A footswitch CC has two codes only. MOD-UI can learn a footswitch onto a continuous parameter, with a minimum and a maximum from its advanced menu. A press moves correctly between those two values. But an edit from the UI that stopped between them became an endpoint, so the screen showed one value and mod-host held a different one.

_publish_switch_cc now sends the two ends of the binding range as CC, and all other values on the WebSocket. Three tests hold this. No user saw the defect.

### Why one control answered for two parameters

A binding is a CC number, and a CC number is an address, not a name. Two parameters can name one address. The old code found the control from the address, then had to ask a second time if that control was really the correct one. Current now keeps the decision of the binder, and control_for reads it. One place resolves the address.

### Removals

* has_footswitch had no reader after the dispatch fork went away, so the field, its two writers and 60 tests are gone
* BypassSource did not earn its keep
* The ws_bridge is not None guards are gone, because the property already asserts that the bridge is there

### Not covered

PluginPanel._send_param writes to ws_bridge directly and does not use _sink_for. So any panel edit ignores the suppression window.